### PR TITLE
referrals Fix for the AllegationPerpetratorHistory and the JMeter

### DIFF
--- a/src/main/java/gov/ca/cwds/rest/services/ScreeningToReferralService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/ScreeningToReferralService.java
@@ -817,7 +817,8 @@ public class ScreeningToReferralService implements CrudsService {
         // create the Allegation Perpetrator History
         gov.ca.cwds.rest.api.domain.cms.AllegationPerpetratorHistory cmsPerpHistory =
             new gov.ca.cwds.rest.api.domain.cms.AllegationPerpetratorHistory(
-                DEFAULT_COUNTY_SPECIFIC_CODE, victimClientId, perpatratorClientId, "2017-07-03");
+                DEFAULT_COUNTY_SPECIFIC_CODE, postedAllegation.getVictimClientId(),
+                postedAllegation.getId(), "2017-07-03");
 
         messageBuilder.addDomainValidationError(validator.validate(cmsPerpHistory));
 


### PR DESCRIPTION
Referrals POST is getting 400 due to the empty VicitimId and AllegationId created by the DefaultAllegationPerperatorHistory. Changed it to take the values from postedAllegation.