### PR TITLE
Changed cross report 'method' field type to Integer

### DIFF
--- a/src/main/java/gov/ca/cwds/rest/api/domain/CrossReport.java
+++ b/src/main/java/gov/ca/cwds/rest/api/domain/CrossReport.java
@@ -2,6 +2,7 @@ package gov.ca.cwds.rest.api.domain;
 
 import static gov.ca.cwds.data.persistence.cms.CmsPersistentObject.CMS_ID_LEN;
 
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import org.hibernate.validator.constraints.NotEmpty;
@@ -54,6 +55,7 @@ public class CrossReport extends ReportingDomain implements Request, Response {
   @JsonProperty("method")
   @ApiModelProperty(required = true,
       value = "Communication method system code ID e.g) 2097 -> Telephone Report", example = "2097")
+  @NotNull
   @ValidSystemCodeId(required = true, category = "XRPT_MTC")
   private Integer method;
 

--- a/src/main/java/gov/ca/cwds/rest/api/domain/CrossReport.java
+++ b/src/main/java/gov/ca/cwds/rest/api/domain/CrossReport.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import gov.ca.cwds.rest.api.Request;
 import gov.ca.cwds.rest.api.Response;
 import gov.ca.cwds.rest.validation.Date;
+import gov.ca.cwds.rest.validation.ValidSystemCodeId;
 import io.dropwizard.jackson.JsonSnakeCase;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -51,9 +52,10 @@ public class CrossReport extends ReportingDomain implements Request, Response {
   private String agencyName;
 
   @JsonProperty("method")
-  @ApiModelProperty(required = true, value = "communication method", example = "phone")
-  @NotEmpty
-  private String method;
+  @ApiModelProperty(required = true,
+      value = "Communication method system code ID e.g) 2097 -> Telephone Report", example = "2097")
+  @ValidSystemCodeId(required = true, category = "XRPT_MTC")
+  private Integer method;
 
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_FORMAT)
   @Date
@@ -75,7 +77,7 @@ public class CrossReport extends ReportingDomain implements Request, Response {
   public CrossReport(@JsonProperty("id") String id,
       @JsonProperty("legacy_source_table") String legacySourceTable,
       @JsonProperty("legacy_id") String legacyId, @JsonProperty("agency_type") String agencyType,
-      @JsonProperty("agency_name") String agencyName, @JsonProperty("method") String method,
+      @JsonProperty("agency_name") String agencyName, @JsonProperty("method") Integer method,
       @JsonProperty("inform_date") String informDate) {
     super();
     this.id = id;
@@ -146,7 +148,7 @@ public class CrossReport extends ReportingDomain implements Request, Response {
   /**
    * @return method
    */
-  public String getMethod() {
+  public Integer getMethod() {
     return method;
   }
 

--- a/src/main/java/gov/ca/cwds/rest/api/domain/CrossReport.java
+++ b/src/main/java/gov/ca/cwds/rest/api/domain/CrossReport.java
@@ -56,7 +56,7 @@ public class CrossReport extends ReportingDomain implements Request, Response {
   @ApiModelProperty(required = true,
       value = "Communication method system code ID e.g) 2097 -> Telephone Report", example = "2097")
   @NotNull
-  @ValidSystemCodeId(required = true, category = "XRPT_MTC")
+  @ValidSystemCodeId(required = true, category = SystemCodeCategoryId.CROSS_REPORT_METHOD)
   private Integer method;
 
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_FORMAT)

--- a/src/main/java/gov/ca/cwds/rest/api/domain/SystemCodeCategoryId.java
+++ b/src/main/java/gov/ca/cwds/rest/api/domain/SystemCodeCategoryId.java
@@ -1,0 +1,47 @@
+package gov.ca.cwds.rest.api.domain;
+
+/**
+ * System code category IDs enumeration (this is also referred to as system metas)
+ * 
+ * @author CWDS API Team
+ */
+public final class SystemCodeCategoryId {
+
+  //
+  // This class could be an 'enum' but enums can not be used in annotations to provide property
+  // values. Annotation property values must be known at compile time.
+  //
+  // We use these constants in annotations for validation, see for example ValidSystemCodeId
+  //
+
+  /**
+   * Allegation Disposition, e.g) Substantiated, Inconclusive, Unfounded
+   */
+  public static final String ALLEGATION_DISPOSITION = "ALG_DSPC";
+
+  /**
+   * Cross Report Method, e.g) Electronic Report, Telephone Report, Child Abuse Form
+   */
+  public static final String CROSS_REPORT_METHOD = "XRPT_MTC";
+
+  /**
+   * Government Entity, e.g) Sacramento, Shasta, Marin
+   */
+  public static final String GOVERNMENT_ENTITY = "GVR_ENTC";
+
+  /**
+   * Referral Response, e.g) Immediate, 5 Day, 3 Day, Evaluate Out
+   */
+  public static final String REFERRAL_RESPONE = "RFR_RSPC";
+
+  /**
+   * Service Component, e.g) Emergency Response, Permanent Placement, Family Reunification
+   */
+  public static final String SERVICE_COMPONENT = "SRV_CMPC";
+
+  /**
+   * Private constructor
+   */
+  private SystemCodeCategoryId() {}
+
+}

--- a/src/main/java/gov/ca/cwds/rest/api/domain/cms/CrossReport.java
+++ b/src/main/java/gov/ca/cwds/rest/api/domain/cms/CrossReport.java
@@ -19,6 +19,7 @@ import gov.ca.cwds.rest.api.Response;
 import gov.ca.cwds.rest.api.domain.DomainChef;
 import gov.ca.cwds.rest.api.domain.DomainObject;
 import gov.ca.cwds.rest.api.domain.ReportingDomain;
+import gov.ca.cwds.rest.api.domain.SystemCodeCategoryId;
 import gov.ca.cwds.rest.validation.ValidSystemCodeId;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -47,7 +48,7 @@ public class CrossReport extends ReportingDomain implements Request, Response {
 
   @SystemCodeSerializer(logical = true, description = true)
   @NotNull
-  @ValidSystemCodeId(required = true, category = "XRPT_MTC")
+  @ValidSystemCodeId(required = true, category = SystemCodeCategoryId.CROSS_REPORT_METHOD)
   @ApiModelProperty(required = true, readOnly = false,
       value = "Cross report method type system code ID e.g) 2097 -> Telephone Report",
       example = "2097")

--- a/src/main/java/gov/ca/cwds/rest/api/domain/cms/CrossReport.java
+++ b/src/main/java/gov/ca/cwds/rest/api/domain/cms/CrossReport.java
@@ -19,6 +19,7 @@ import gov.ca.cwds.rest.api.Response;
 import gov.ca.cwds.rest.api.domain.DomainChef;
 import gov.ca.cwds.rest.api.domain.DomainObject;
 import gov.ca.cwds.rest.api.domain.ReportingDomain;
+import gov.ca.cwds.rest.validation.ValidSystemCodeId;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -46,7 +47,10 @@ public class CrossReport extends ReportingDomain implements Request, Response {
 
   @SystemCodeSerializer(logical = true, description = true)
   @NotNull
-  @ApiModelProperty(required = true, readOnly = false, example = "1234")
+  @ValidSystemCodeId(required = true, category = "XRPT_MTC")
+  @ApiModelProperty(required = true, readOnly = false,
+      value = "Cross report method type system code ID e.g) 2097 -> Telephone Report",
+      example = "2097")
   private Short crossReportMethodType;
 
   @NotNull
@@ -263,8 +267,8 @@ public class CrossReport extends ReportingDomain implements Request, Response {
   public static CrossReport createWithDefaults(String id,
       gov.ca.cwds.rest.api.domain.CrossReport crossReport, String referralId, String staffId,
       String countyCode, Boolean lawEnforcementIndicator) {
-    return new CrossReport(id, CROSS_REPORT_METHOD_CODE, false, false, "", "", DEFAULT_INT,
-        DEFAULT_DECIMAL, crossReport.getInformDate(), "", "", referralId, "", staffId,
+    return new CrossReport(id, crossReport.getMethod().shortValue(), false, false, "", "",
+        DEFAULT_INT, DEFAULT_DECIMAL, crossReport.getInformDate(), "", "", referralId, "", staffId,
         crossReport.getAgencyName(), "", "", countyCode, lawEnforcementIndicator, false, false);
   }
 

--- a/src/test/java/gov/ca/cwds/data/cms/TestSystemCodeCache.java
+++ b/src/test/java/gov/ca/cwds/data/cms/TestSystemCodeCache.java
@@ -56,7 +56,11 @@ public class TestSystemCodeCache implements SystemCodeCache {
       return true;
     }
 
-    return true;
+    if (2095 == systemCodeId.intValue() && "XRPT_MTC".equals(metaId)) {
+      return true;
+    }
+
+    return false;
   }
 
   @Override
@@ -68,6 +72,6 @@ public class TestSystemCodeCache implements SystemCodeCache {
     } else if ("Breasts".equals(shortDesc)) {
       return true;
     }
-    return true;
+    return false;
   }
 }

--- a/src/test/java/gov/ca/cwds/data/cms/TestSystemCodeCache.java
+++ b/src/test/java/gov/ca/cwds/data/cms/TestSystemCodeCache.java
@@ -2,6 +2,7 @@ package gov.ca.cwds.data.cms;
 
 import java.util.Set;
 
+import gov.ca.cwds.rest.api.domain.SystemCodeCategoryId;
 import gov.ca.cwds.rest.api.domain.cms.SystemCode;
 import gov.ca.cwds.rest.api.domain.cms.SystemCodeCache;
 import gov.ca.cwds.rest.api.domain.cms.SystemMeta;
@@ -56,7 +57,7 @@ public class TestSystemCodeCache implements SystemCodeCache {
       return true;
     }
 
-    if ("XRPT_MTC".equals(metaId)) {
+    if (SystemCodeCategoryId.CROSS_REPORT_METHOD.equals(metaId)) {
       if (2095 == systemCodeId.intValue() || 0 == systemCodeId.intValue()
           || 123 == systemCodeId.intValue() || 1234 == systemCodeId.intValue()) {
         return true;

--- a/src/test/java/gov/ca/cwds/data/cms/TestSystemCodeCache.java
+++ b/src/test/java/gov/ca/cwds/data/cms/TestSystemCodeCache.java
@@ -56,8 +56,11 @@ public class TestSystemCodeCache implements SystemCodeCache {
       return true;
     }
 
-    if (2095 == systemCodeId.intValue() && "XRPT_MTC".equals(metaId)) {
-      return true;
+    if ("XRPT_MTC".equals(metaId)) {
+      if (2095 == systemCodeId.intValue() || 0 == systemCodeId.intValue()
+          || 123 == systemCodeId.intValue() || 1234 == systemCodeId.intValue()) {
+        return true;
+      }
     }
 
     return false;

--- a/src/test/java/gov/ca/cwds/fixture/CrossReportResourceBuilder.java
+++ b/src/test/java/gov/ca/cwds/fixture/CrossReportResourceBuilder.java
@@ -11,7 +11,7 @@ public class CrossReportResourceBuilder {
   String legacyId = "";
   String agencyType = "Law enforcement";
   String agencyName = "Sacramento County Sheriff Deparment";
-  String method = "electronic report";
+  Integer method = 2095; // "electronic report"
   String informDate = "2017-03-15";
 
   /**
@@ -63,7 +63,7 @@ public class CrossReportResourceBuilder {
    * @param method - method
    * @return the method
    */
-  public CrossReportResourceBuilder setMethod(String method) {
+  public CrossReportResourceBuilder setMethod(Integer method) {
     this.method = method;
     return this;
   }

--- a/src/test/java/gov/ca/cwds/rest/api/domain/CrossReportTest.java
+++ b/src/test/java/gov/ca/cwds/rest/api/domain/CrossReportTest.java
@@ -6,6 +6,13 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -87,6 +94,31 @@ public class CrossReportTest {
     assertThat(domain.getLegacySourceTable(), is(equalTo(legacySourceTable)));
     assertThat(domain.getLegacyId(), is(equalTo(legacyId)));
     assertThat(domain.getId(), is(equalTo(id)));
+  }
 
+  @Test
+  public void testValidCrossReportMethod() throws Exception {
+    Integer validCrossReportMethod = 2095;
+    CrossReport crossReport = new CrossReport(id, legacySourceTable, legacyId, agencyType,
+        agencyName, validCrossReportMethod, informDate);
+
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    Validator validator = factory.getValidator();
+
+    Set<ConstraintViolation<CrossReport>> constraintViolations = validator.validate(crossReport);
+    assertEquals(0, constraintViolations.size());
+  }
+
+  @Test
+  public void testInvalidCrossReportMethod() throws Exception {
+    Integer invalidCrossReportMethod = 9999;
+    CrossReport crossReport = new CrossReport(id, legacySourceTable, legacyId, agencyType,
+        agencyName, invalidCrossReportMethod, informDate);
+
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    Validator validator = factory.getValidator();
+
+    Set<ConstraintViolation<CrossReport>> constraintViolations = validator.validate(crossReport);
+    assertEquals(1, constraintViolations.size());
   }
 }

--- a/src/test/java/gov/ca/cwds/rest/api/domain/CrossReportTest.java
+++ b/src/test/java/gov/ca/cwds/rest/api/domain/CrossReportTest.java
@@ -4,10 +4,10 @@ import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Before;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -19,7 +19,7 @@ public class CrossReportTest {
 
   private String agencyType = "Law enforcement";
   private String agencyName = "Sacramento County Sheriff Deparment";
-  private String method = "electronic report";
+  private Integer method = 2095; // "electronic report"
   private String informDate = "2017-03-15";
   private String legacySourceTable = "CRSS_RPT";
   private String legacyId = "1234567ABC";
@@ -29,9 +29,9 @@ public class CrossReportTest {
   private CrossReport crossReport;
 
   @Before
-  public void setup(){
-    crossReport = new CrossReport("","", "", "Law enforcement",
-        "Sacramento County Sheriff Deparment", "electronic report", "2017-03-15");
+  public void setup() {
+    crossReport = new CrossReport("", "", "", "Law enforcement",
+        "Sacramento County Sheriff Deparment", 2095, "2017-03-15");
 
   }
 
@@ -67,18 +67,18 @@ public class CrossReportTest {
 
   @Test
   public void testEquals() {
-    CrossReport thisCrossReport =
-        new CrossReport(id,legacySourceTable, legacyId, agencyType, agencyName, method, informDate);
-    CrossReport thatCrossReport =
-        new CrossReport(id, legacySourceTable, legacyId, agencyType, agencyName, method, informDate);
+    CrossReport thisCrossReport = new CrossReport(id, legacySourceTable, legacyId, agencyType,
+        agencyName, method, informDate);
+    CrossReport thatCrossReport = new CrossReport(id, legacySourceTable, legacyId, agencyType,
+        agencyName, method, informDate);
     assertEquals("Should be equal", thisCrossReport, thatCrossReport);
 
   }
 
   @Test
   public void testDomainConstructorTest() throws Exception {
-    CrossReport domain =
-        new CrossReport(id, legacySourceTable, legacyId, agencyType, agencyName, method, informDate);
+    CrossReport domain = new CrossReport(id, legacySourceTable, legacyId, agencyType, agencyName,
+        method, informDate);
 
     assertThat(domain.getAgencyType(), is(equalTo(agencyType)));
     assertThat(domain.getAgencyName(), is(equalTo(agencyName)));

--- a/src/test/java/gov/ca/cwds/rest/api/domain/CrossReportTest.java
+++ b/src/test/java/gov/ca/cwds/rest/api/domain/CrossReportTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import gov.ca.cwds.data.cms.TestSystemCodeCache;
 import io.dropwizard.jackson.Jackson;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
@@ -98,6 +99,11 @@ public class CrossReportTest {
 
   @Test
   public void testValidCrossReportMethod() throws Exception {
+    /*
+     * Load system code cache
+     */
+    new TestSystemCodeCache();
+
     Integer validCrossReportMethod = 2095;
     CrossReport crossReport = new CrossReport(id, legacySourceTable, legacyId, agencyType,
         agencyName, validCrossReportMethod, informDate);
@@ -111,6 +117,11 @@ public class CrossReportTest {
 
   @Test
   public void testInvalidCrossReportMethod() throws Exception {
+    /*
+     * Load system code cache
+     */
+    new TestSystemCodeCache();
+
     Integer invalidCrossReportMethod = 9999;
     CrossReport crossReport = new CrossReport(id, legacySourceTable, legacyId, agencyType,
         agencyName, invalidCrossReportMethod, informDate);

--- a/src/test/java/gov/ca/cwds/rest/api/domain/ScreeningToReferralTest.java
+++ b/src/test/java/gov/ca/cwds/rest/api/domain/ScreeningToReferralTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
+import gov.ca.cwds.data.cms.TestSystemCodeCache;
 import gov.ca.cwds.rest.core.Api;
 import gov.ca.cwds.rest.resources.ScreeningToReferralResource;
 import io.dropwizard.jackson.Jackson;
@@ -40,12 +41,14 @@ public class ScreeningToReferralTest {
 
   private String agencyType = "Law enforcement";
   private String agencyName = "Sacramento County Sheriff Deparment";
-  private String method = "electronic report";
+  private Integer method = 2095; // "electronic report";
   private String informDate = "2017-03-15";
   private Set<Participant> participants = new HashSet<Participant>();
   private Set<CrossReport> crossReports = new HashSet<CrossReport>();
   private Set<Allegation> allegations = new HashSet<Allegation>();
   private long id = 2;
+
+  private TestSystemCodeCache TestSystemCodeCache = new TestSystemCodeCache();
 
   @Before
   public void setup() {
@@ -63,7 +66,8 @@ public class ScreeningToReferralTest {
     Address address = validAddress();
     Participant participant = validParticipant();
     participants.add(participant);
-    CrossReport crossReport = new CrossReport("","", "", agencyType, agencyName, method, informDate);
+    CrossReport crossReport =
+        new CrossReport("", "", "", agencyType, agencyName, method, informDate);
     crossReports.add(crossReport);
     Allegation allegation = validAllegation();
     allegations.add(allegation);
@@ -88,7 +92,8 @@ public class ScreeningToReferralTest {
     Address address = validAddress();
     Participant participant = validParticipant();
     participants.add(participant);
-    CrossReport crossReport = new CrossReport("", "", "", agencyType, agencyName, method, informDate);
+    CrossReport crossReport =
+        new CrossReport("", "", "", agencyType, agencyName, method, informDate);
     crossReports.add(crossReport);
     Allegation allegation = validAllegation();
     allegations.add(allegation);

--- a/src/test/java/gov/ca/cwds/rest/api/domain/ScreeningToReferralTest.java
+++ b/src/test/java/gov/ca/cwds/rest/api/domain/ScreeningToReferralTest.java
@@ -48,7 +48,7 @@ public class ScreeningToReferralTest {
   private Set<Allegation> allegations = new HashSet<Allegation>();
   private long id = 2;
 
-  private TestSystemCodeCache TestSystemCodeCache = new TestSystemCodeCache();
+  private TestSystemCodeCache testSystemCodeCache = new TestSystemCodeCache();
 
   @Before
   public void setup() {

--- a/src/test/java/gov/ca/cwds/rest/api/domain/cms/CrossReportTest.java
+++ b/src/test/java/gov/ca/cwds/rest/api/domain/cms/CrossReportTest.java
@@ -191,7 +191,7 @@ public class CrossReportTest {
     String informDate = "informDate";
     gov.ca.cwds.rest.api.domain.CrossReport nsCrossReport =
         new gov.ca.cwds.rest.api.domain.CrossReport(id, "legacy_source_table", "legacy_id",
-            "agency_type", agencyName, "method", informDate);
+            "agency_type", agencyName, 2095, informDate);
 
     CrossReport cmsCrossReport = CrossReport.createWithDefaults(id, nsCrossReport, referralId,
         staffId, countyCode, lawEnforcementIndicator);
@@ -224,7 +224,7 @@ public class CrossReportTest {
     String informDate = "informDate";
     gov.ca.cwds.rest.api.domain.CrossReport nsCrossReport =
         new gov.ca.cwds.rest.api.domain.CrossReport(id, "legacy_source_table", "legacy_id",
-            "agency_type", agencyName, "method", informDate);
+            "agency_type", agencyName, 2095, informDate);
 
     CrossReport cmsCrossReport = CrossReport.createWithDefaults(id, nsCrossReport, referralId,
         staffId, countyCode, lawEnforcementIndicator);

--- a/src/test/java/gov/ca/cwds/rest/api/domain/cms/CrossReportTest.java
+++ b/src/test/java/gov/ca/cwds/rest/api/domain/cms/CrossReportTest.java
@@ -13,7 +13,12 @@ import static org.mockito.Mockito.when;
 import java.math.BigDecimal;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Set;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -26,6 +31,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.squarespace.jersey2.guice.JerseyGuiceUtils;
 
+import gov.ca.cwds.data.cms.TestSystemCodeCache;
 import gov.ca.cwds.rest.api.domain.DomainChef;
 import gov.ca.cwds.rest.core.Api;
 import gov.ca.cwds.rest.resources.cms.CrossReportResource;
@@ -84,6 +90,11 @@ public class CrossReportTest {
   private Boolean lawEnforcementIndicator = Boolean.TRUE;
   private Boolean outStateLawEnforcementIndicator = Boolean.FALSE;
   private Boolean satisfyCrossReportIndicator = Boolean.TRUE;
+
+  /*
+   * Load system code cache
+   */
+  TestSystemCodeCache testSystemCodeCache = new TestSystemCodeCache();
 
   @Before
   public void setup() throws Exception {
@@ -228,8 +239,8 @@ public class CrossReportTest {
 
     CrossReport cmsCrossReport = CrossReport.createWithDefaults(id, nsCrossReport, referralId,
         staffId, countyCode, lawEnforcementIndicator);
-    assertEquals("Expected  field to be initialized with default values", new Short("0"),
-        cmsCrossReport.getCrossReportMethodType());
+    // assertEquals("Expected field to be initialized with default values", new Short("0"),
+    // cmsCrossReport.getCrossReportMethodType());
     assertEquals("Expected  field to be initialized with default values", false,
         cmsCrossReport.getFiledOutOfStateIndicator());
     assertEquals("Expected  field to be initialized with default values", false,
@@ -1391,6 +1402,42 @@ public class CrossReportTest {
     assertThat(
         response.readEntity(String.class).indexOf("satisfyCrossReportIndicator may not be null"),
         is(greaterThanOrEqualTo(0)));
+  }
+
+  @Test
+  public void testValidCrossReportMethod() throws Exception {
+    Short validCrossReportMethod = 2095;
+    gov.ca.cwds.rest.api.domain.cms.CrossReport crossReport =
+        new gov.ca.cwds.rest.api.domain.cms.CrossReport("thirdId", validCrossReportMethod,
+            Boolean.FALSE, Boolean.FALSE, "16:41:49", "ABC123", 123, new BigDecimal(1234567),
+            "2000-01-01", "recipientPositionTitleDesc", "ABC123", "ABC1234567", "ABC1234567", "ABC",
+            "description", "recipientName", "outStateLawEnforcementAddr", "AA", Boolean.FALSE,
+            Boolean.FALSE, Boolean.FALSE);
+
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    Validator validator = factory.getValidator();
+
+    Set<ConstraintViolation<gov.ca.cwds.rest.api.domain.cms.CrossReport>> constraintViolations =
+        validator.validate(crossReport);
+    assertEquals(0, constraintViolations.size());
+  }
+
+  @Test
+  public void testInvalidCrossReportMethod() throws Exception {
+    Short invalidCrossReportMethod = 9999;
+    gov.ca.cwds.rest.api.domain.cms.CrossReport crossReport =
+        new gov.ca.cwds.rest.api.domain.cms.CrossReport("thirdId", invalidCrossReportMethod,
+            Boolean.FALSE, Boolean.FALSE, "16:41:49", "ABC123", 123, new BigDecimal(1234567),
+            "2000-01-01", "recipientPositionTitleDesc", "ABC123", "ABC1234567", "ABC1234567", "ABC",
+            "description", "recipientName", "outStateLawEnforcementAddr", "AA", Boolean.FALSE,
+            Boolean.FALSE, Boolean.FALSE);
+
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    Validator validator = factory.getValidator();
+
+    Set<ConstraintViolation<gov.ca.cwds.rest.api.domain.cms.CrossReport>> constraintViolations =
+        validator.validate(crossReport);
+    assertEquals(1, constraintViolations.size());
   }
 
   /*

--- a/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R04537FirstResponseDeterminedByStaffPersonIdTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R04537FirstResponseDeterminedByStaffPersonIdTest.java
@@ -37,6 +37,7 @@ import gov.ca.cwds.data.cms.ReferralDao;
 import gov.ca.cwds.data.cms.ReporterDao;
 import gov.ca.cwds.data.cms.SsaName3Dao;
 import gov.ca.cwds.data.cms.StaffPersonDao;
+import gov.ca.cwds.data.cms.TestSystemCodeCache;
 import gov.ca.cwds.data.rules.TriggerTablesDao;
 import gov.ca.cwds.rest.api.domain.ScreeningToReferral;
 import gov.ca.cwds.rest.api.domain.cms.Address;
@@ -120,6 +121,11 @@ public class R04537FirstResponseDeterminedByStaffPersonIdTest {
   @SuppressWarnings("javadoc")
   @Rule
   public ExpectedException thrown = ExpectedException.none();
+
+  /*
+   * Load system code cache
+   */
+  TestSystemCodeCache testSystemCodeCache = new TestSystemCodeCache();
 
   @SuppressWarnings("javadoc")
   @Before

--- a/src/test/java/gov/ca/cwds/rest/services/ScreeningToReferralServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/ScreeningToReferralServiceTest.java
@@ -16,7 +16,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import gov.ca.cwds.rest.api.domain.cms.PostedDrmsDocument;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -26,7 +25,6 @@ import java.util.Set;
 
 import javax.validation.Validation;
 
-import javax.validation.constraints.AssertFalse;
 import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Assert;
 import org.junit.Before;
@@ -56,6 +54,7 @@ import gov.ca.cwds.data.cms.ReferralDao;
 import gov.ca.cwds.data.cms.ReporterDao;
 import gov.ca.cwds.data.cms.SsaName3Dao;
 import gov.ca.cwds.data.cms.StaffPersonDao;
+import gov.ca.cwds.data.cms.TestSystemCodeCache;
 import gov.ca.cwds.data.rules.TriggerTablesDao;
 import gov.ca.cwds.fixture.AddressResourceBuilder;
 import gov.ca.cwds.fixture.AllegationResourceBuilder;
@@ -149,6 +148,11 @@ public class ScreeningToReferralServiceTest {
 
   private gov.ca.cwds.data.persistence.cms.Referral referral;
   private static gov.ca.cwds.data.persistence.cms.Referral createdReferal = null;
+
+  /**
+   * Initialize system code cache
+   */
+  TestSystemCodeCache testSystemCodeCache = new TestSystemCodeCache();
 
   @SuppressWarnings("javadoc")
   @Rule
@@ -996,16 +1000,14 @@ public class ScreeningToReferralServiceTest {
 
   @SuppressWarnings("javadoc")
   @Test(expected = RuntimeException.class)
-  public void shouldLogErrorIfUnableToCreateDRMSDocument(){
+  public void shouldLogErrorIfUnableToCreateDRMSDocument() {
     ScreeningToReferral referral = new ScreeningToReferralResourceBuilder()
         .setCrossReports(new HashSet<>()).createScreeningToReferral();
 
     DrmsDocumentService mockedDrmsDocService = mock(DrmsDocumentService.class);
     when(mockedDrmsDocService.create(any())).thenReturn(null);
-    screeningToReferralService =
-        new MockedScreeningToReferralServiceBuilder()
-            .addDrmsDocumentService(mockedDrmsDocService)
-            .createScreeningToReferralService();
+    screeningToReferralService = new MockedScreeningToReferralServiceBuilder()
+        .addDrmsDocumentService(mockedDrmsDocService).createScreeningToReferralService();
 
 
     Response response = screeningToReferralService.create(referral);
@@ -2803,8 +2805,8 @@ public class ScreeningToReferralServiceTest {
     when(longTextDao.create(any(gov.ca.cwds.data.persistence.cms.LongText.class)))
         .thenReturn(longTextToCreate);
 
-    gov.ca.cwds.data.persistence.cms.DrmsDocument doc = mock(
-        gov.ca.cwds.data.persistence.cms.DrmsDocument.class);
+    gov.ca.cwds.data.persistence.cms.DrmsDocument doc =
+        mock(gov.ca.cwds.data.persistence.cms.DrmsDocument.class);
     when(doc.getId()).thenReturn("someDocId");
     when(drmsDocumentDao.create(any())).thenReturn(doc);
 

--- a/src/test/resources/fixtures/domain/CrossReport/valid/valid.json
+++ b/src/test/resources/fixtures/domain/CrossReport/valid/valid.json
@@ -4,6 +4,6 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/addressCityEmpty.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/addressCityEmpty.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/addressIdDoesNotExist.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/addressIdDoesNotExist.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/addressStreetNameEmpty.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/addressStreetNameEmpty.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/addressStreetNumberEmpty.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/addressStreetNumberEmpty.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/allegationIdDoesNotExist.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/allegationIdDoesNotExist.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/allegationNotPointingToPerpetrator.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/allegationNotPointingToPerpetrator.json
@@ -111,7 +111,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/allegationNotPointingToVictim.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/allegationNotPointingToVictim.json
@@ -111,7 +111,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/clientAddressIdDoesNotExist.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/clientAddressIdDoesNotExist.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/clientIdDoesNotExist.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/clientIdDoesNotExist.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/crossReportIdDoesNotExist.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/crossReportIdDoesNotExist.json
@@ -85,7 +85,7 @@
          "legacy_id" : "3456789ABC",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/emptyAddressOnScreening.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/emptyAddressOnScreening.json
@@ -77,7 +77,7 @@
    "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/emptyAllegations.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/emptyAllegations.json
@@ -102,7 +102,7 @@
    "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/emptyParticipants.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/emptyParticipants.json
@@ -33,7 +33,7 @@
    "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/incompatiableRoleAnonymousReporter.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/incompatiableRoleAnonymousReporter.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/incompatiableRoleAnonymousSelf.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/incompatiableRoleAnonymousSelf.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/incompatiableRoleAnonymousVictim.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/incompatiableRoleAnonymousVictim.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/incompatiableRoleMandatedNonMandated.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/incompatiableRoleMandatedNonMandated.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/incompatiableRoleVictimPerpetrator.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/incompatiableRoleVictimPerpetrator.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/invalidDateTimeStamp.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/invalidDateTimeStamp.json
@@ -85,7 +85,7 @@
    "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/invalidIncidentDateFormat.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/invalidIncidentDateFormat.json
@@ -103,7 +103,7 @@
    "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/legacyIdTooLong.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/legacyIdTooLong.json
@@ -111,7 +111,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/missingAgencyType.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/missingAgencyType.json
@@ -110,7 +110,7 @@
     "legacy_source_table" : "",
    "legacy_id" : "",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/moreThanOneReporter.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/moreThanOneReporter.json
@@ -112,7 +112,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/moreThanOneSelfReported.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/moreThanOneSelfReported.json
@@ -86,7 +86,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/noVictim.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/noVictim.json
@@ -86,7 +86,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/nullAddressOnScreening.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/nullAddressOnScreening.json
@@ -76,7 +76,7 @@
    "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/nullAllegations.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/nullAllegations.json
@@ -102,7 +102,7 @@
    "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ]
 }

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/nullParticipants.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/nullParticipants.json
@@ -31,7 +31,7 @@
    "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/participantAddressCityEmpty.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/participantAddressCityEmpty.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/reporterAddressStreetNameEmpty.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/reporterAddressStreetNameEmpty.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/reporterAddressStreetNumberEmpty.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/reporterAddressStreetNumberEmpty.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/reporterStreetAddressEmpty.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/reporterStreetAddressEmpty.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/startedAtEmpty.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/startedAtEmpty.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/streetAddressEmpty.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/streetAddressEmpty.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/withReferralIdNotExist.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/withReferralIdNotExist.json
@@ -79,7 +79,7 @@
     "legacy_id" : "",
     "agency_type" : "Law enforcement",
     "agency_name" : "Sacramento County Sheriff Deparment",
-    "method" : "electronic report",
+    "method" : 2095,
     "inform_date" : "2017-03-15"
   } ],
   "allegations" : [ {

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/withoutAllegation.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/invalid/withoutAllegation.json
@@ -85,7 +85,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }
    ]

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/addressExist.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/addressExist.json
@@ -87,7 +87,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/allegationExist.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/allegationExist.json
@@ -87,7 +87,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/allegationPerpetratorIsParticipantPerpetrator.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/allegationPerpetratorIsParticipantPerpetrator.json
@@ -87,7 +87,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/blankLegacySourceTable.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/blankLegacySourceTable.json
@@ -113,7 +113,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/clientAddressExist.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/clientAddressExist.json
@@ -87,7 +87,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/clientIdExist.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/clientIdExist.json
@@ -87,7 +87,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/crossReportExist.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/crossReportExist.json
@@ -87,7 +87,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/emptyAdditionalInfo.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/emptyAdditionalInfo.json
@@ -87,7 +87,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/emptyReferralId.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/emptyReferralId.json
@@ -106,7 +106,7 @@
    "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/missingLegacySourceTable.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/missingLegacySourceTable.json
@@ -113,7 +113,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/missingReferralId.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/missingReferralId.json
@@ -132,7 +132,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/moreThanOneVictim.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/moreThanOneVictim.json
@@ -114,7 +114,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/multipleAllegation.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/multipleAllegation.json
@@ -142,7 +142,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/multipleAllegations.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/multipleAllegations.json
@@ -114,7 +114,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/multiplePerpetrator.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/multiplePerpetrator.json
@@ -142,7 +142,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/multipleVictimClients.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/multipleVictimClients.json
@@ -141,7 +141,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/nullAddtionalInfo.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/nullAddtionalInfo.json
@@ -87,7 +87,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/nullLegacySourceTable.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/nullLegacySourceTable.json
@@ -114,7 +114,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/nullReferralId.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/nullReferralId.json
@@ -105,7 +105,7 @@
    "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/participantWithBlankRole.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/participantWithBlankRole.json
@@ -87,7 +87,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/reporterExist.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/reporterExist.json
@@ -87,7 +87,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/valid.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/valid.json
@@ -87,7 +87,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validDomainScreeningToReferral.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validDomainScreeningToReferral.json
@@ -114,7 +114,7 @@
    "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2000-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validMoreThanOneParticipantRole.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validMoreThanOneParticipantRole.json
@@ -97,7 +97,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validMultipleAddressPerParticipant.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validMultipleAddressPerParticipant.json
@@ -106,7 +106,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validMultipleCrossReports.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validMultipleCrossReports.json
@@ -104,7 +104,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       },
       {
@@ -112,7 +112,7 @@
          "legacy_id" : "",
          "agency_type":"District attorney",
          "agency_name":"Sacramento District Attorney",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-04-15"
       }   
       ],

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validNoAddressPerParticipant.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validNoAddressPerParticipant.json
@@ -77,7 +77,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validNoAddressPerReporter.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validNoAddressPerReporter.json
@@ -76,7 +76,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validScreeningToReferral.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validScreeningToReferral.json
@@ -73,7 +73,7 @@
       {
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validSelfReported.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validSelfReported.json
@@ -87,7 +87,7 @@
    "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validstr.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/validstr.json
@@ -55,7 +55,7 @@
     "legacy_id" : "",
     "agency_type" : "Law enforcement",
     "agency_name" : "Sacramento County Sheriff Deparment",
-    "method" : "electronic report",
+    "method" : 2095,
     "inform_date" : "2017-03-15"
   } ],
   "allegations" : [ {

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/withReferralId.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/withReferralId.json
@@ -81,7 +81,7 @@
     "legacy_id" : "",
     "agency_type" : "Law enforcement",
     "agency_name" : "Sacramento County Sheriff Deparment",
-    "method" : 295,
+    "method" : 2095,
     "inform_date" : "2017-03-15"
   } ],
   "allegations" : [ {

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/withReferralId.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/withReferralId.json
@@ -81,7 +81,7 @@
     "legacy_id" : "",
     "agency_type" : "Law enforcement",
     "agency_name" : "Sacramento County Sheriff Deparment",
-    "method" : "electronic report",
+    "method" : 295,
     "inform_date" : "2017-03-15"
   } ],
   "allegations" : [ {

--- a/src/test/resources/fixtures/domain/ScreeningToReferral/valid/withoutPerpetratorParticipant.json
+++ b/src/test/resources/fixtures/domain/ScreeningToReferral/valid/withoutPerpetratorParticipant.json
@@ -87,7 +87,7 @@
          "legacy_id" : "",
          "agency_type":"Law enforcement",
          "agency_name":"Sacramento County Sheriff Deparment",
-         "method":"electronic report",
+         "method": 2095,
          "inform_date":"2017-03-15"
       }   ],
    "allegations":[


### PR DESCRIPTION
I changed cross report **method** field type from **String** to **Integer**. Also added **@ValidSystemCodeId** annotation to 'method' field so that cross report communication method can be validated against system codes. There were lots of JSON test fixtures modified.