### PR TITLE
#149044497 CountyOwnership on the clientAddressService and AssignmentService

### DIFF
--- a/src/main/java/gov/ca/cwds/rest/business/rules/NonLACountyTriggers.java
+++ b/src/main/java/gov/ca/cwds/rest/business/rules/NonLACountyTriggers.java
@@ -9,10 +9,17 @@ import org.slf4j.LoggerFactory;
 import com.google.inject.Inject;
 
 import gov.ca.cwds.data.cms.CountyOwnershipDao;
+import gov.ca.cwds.data.cms.ReferralClientDao;
+import gov.ca.cwds.data.cms.ReferralDao;
+import gov.ca.cwds.data.persistence.cms.Assignment;
 import gov.ca.cwds.data.persistence.cms.Client;
+import gov.ca.cwds.data.persistence.cms.ClientAddress;
 import gov.ca.cwds.data.persistence.cms.CountyOwnership;
+import gov.ca.cwds.data.persistence.cms.Referral;
 import gov.ca.cwds.data.persistence.cms.ReferralClient;
+import gov.ca.cwds.data.persistence.cms.ReferralClient.PrimaryKey;
 import gov.ca.cwds.data.rules.TriggerTableException;
+
 
 /**
  * Business layer object to work on Non LA Triggers
@@ -27,21 +34,34 @@ import gov.ca.cwds.data.rules.TriggerTableException;
  */
 public class NonLACountyTriggers {
 
+  private static final String COUNTY_OWNERSHIP_UNABLE_TO_TRIGGER =
+      "CountyOwnership Unable to Trigger : {}";
   private static final String CLIENT_ENTITY_CODE = "C";
+  private static final String ADDRESS_ENTITY_CODE = "A";
+  private static final String REFERRAL_ENTITY_CODE = "R";
   private static final String SET_FLAG = "Y";
   private static final String FLAG = "Flag";
   private static final String SET_COUNTY = "setCounty";
+  private static final String TYPE_OF_ASSIGNMENT_CODE = "P";
+  private static final String REFERRAL_ESTABLISHED_CODE = "R";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(NonLACountyTriggers.class);
 
   private CountyOwnershipDao countyOwnershipDao;
+  private ReferralDao referralDao;
+  private ReferralClientDao referralClientDao;
 
   /**
    * @param countyOwnershipDao - countyOwnershipDao
+   * @param referralDao - referralDao
+   * @param referralClientDao - referralClientDao
    */
   @Inject
-  public NonLACountyTriggers(CountyOwnershipDao countyOwnershipDao) {
+  public NonLACountyTriggers(CountyOwnershipDao countyOwnershipDao, ReferralDao referralDao,
+      ReferralClientDao referralClientDao) {
     this.countyOwnershipDao = countyOwnershipDao;
+    this.referralDao = referralDao;
+    this.referralClientDao = referralClientDao;
   }
 
   /**
@@ -75,7 +95,7 @@ public class NonLACountyTriggers {
       method.invoke(countyOwnership, SET_FLAG);
     } catch (NoSuchMethodException | SecurityException | IllegalAccessException
         | IllegalArgumentException | InvocationTargetException e) {
-      LOGGER.info("CountyOwnership Unable to Trigger : {}", countyOwnership);
+      LOGGER.info(COUNTY_OWNERSHIP_UNABLE_TO_TRIGGER, countyOwnership);
       LOGGER.error(e.getMessage(), e);
       throw new TriggerTableException();
     }
@@ -86,6 +106,79 @@ public class NonLACountyTriggers {
       countyOwnershipDao.create(countyOwnership);
     }
 
+  }
+
+  /**
+   * @param managedClientAddress clientAddress creates or updates the countyOwnership with the
+   *        Address foreign key
+   */
+  public void createAndUpdateClientAddressCoutyOwnership(ClientAddress managedClientAddress) {
+    Boolean countyExists = true;
+    CountyOwnership countyOwnership = countyOwnershipDao.find(managedClientAddress.getFkAddress());
+    if (countyOwnership == null) {
+      countyExists = false;
+      countyOwnership = new CountyOwnership();
+      countyOwnership.setEntityId(managedClientAddress.getFkAddress());
+      countyOwnership.setEntityCode(ADDRESS_ENTITY_CODE);
+    }
+    ReferralClient referralClient = referralClientDao.find(
+        new PrimaryKey(managedClientAddress.getFkReferral(), managedClientAddress.getFkClient()));
+    String methodName = SET_COUNTY + referralClient.getCountySpecificCode() + FLAG;
+    Method method = null;
+    try {
+      method = countyOwnership.getClass().getMethod(methodName, String.class);
+      method.invoke(countyOwnership, SET_FLAG);
+    } catch (NoSuchMethodException | IllegalAccessException | IllegalArgumentException
+        | InvocationTargetException e) {
+      LOGGER.info(COUNTY_OWNERSHIP_UNABLE_TO_TRIGGER, countyOwnership);
+      LOGGER.error(e.getMessage(), e);
+      throw new TriggerTableException();
+    }
+
+    if (countyExists) {
+      countyOwnershipDao.update(countyOwnership);
+    } else {
+      countyOwnershipDao.create(countyOwnership);
+    }
+
+  }
+
+  /**
+   * @param managed referral creates or updates the countyOwnership bases on the Assignment
+   *        establishedCode with teh referral foreign key
+   */
+  public void createAndUpdateReferralCoutyOwnership(Assignment managed) {
+    Boolean countyExists = true;
+    if (managed.getTypeOfAssignmentCode() != TYPE_OF_ASSIGNMENT_CODE
+        || managed.getEstablishedForCode() != REFERRAL_ESTABLISHED_CODE) {
+      return;
+    }
+
+    CountyOwnership countyOwnership = countyOwnershipDao.find(managed.getEstablishedForId());
+    if (countyOwnership == null) {
+      countyExists = false;
+      countyOwnership = new CountyOwnership();
+      countyOwnership.setEntityId(managed.getEstablishedForId());
+      countyOwnership.setEntityCode(REFERRAL_ENTITY_CODE);
+    }
+    Referral referral = referralDao.find(managed.getEstablishedForId());
+    String methodName = SET_COUNTY + referral.getCountySpecificCode() + FLAG;
+    Method method = null;
+    try {
+      method = countyOwnership.getClass().getMethod(methodName, String.class);
+      method.invoke(countyOwnership, SET_FLAG);
+    } catch (NoSuchMethodException | SecurityException | IllegalAccessException
+        | IllegalArgumentException | InvocationTargetException e) {
+      LOGGER.info(COUNTY_OWNERSHIP_UNABLE_TO_TRIGGER, countyOwnership);
+      LOGGER.error(e.getMessage(), e);
+      throw new TriggerTableException();
+    }
+
+    if (countyExists) {
+      countyOwnershipDao.update(countyOwnership);
+    } else {
+      countyOwnershipDao.create(countyOwnership);
+    }
   }
 
 }

--- a/src/main/java/gov/ca/cwds/rest/services/cms/ClientAddressService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/cms/ClientAddressService.java
@@ -23,6 +23,7 @@ import gov.ca.cwds.rest.api.Request;
 import gov.ca.cwds.rest.api.Response;
 import gov.ca.cwds.rest.api.domain.Participant;
 import gov.ca.cwds.rest.business.rules.LACountyTrigger;
+import gov.ca.cwds.rest.business.rules.NonLACountyTriggers;
 import gov.ca.cwds.rest.services.CrudsService;
 import gov.ca.cwds.rest.services.ServiceException;
 import gov.ca.cwds.rest.util.IdGenerator;
@@ -39,6 +40,7 @@ public class ClientAddressService implements CrudsService {
   private StaffPersonDao staffpersonDao;
   private TriggerTablesDao triggerTablesDao;
   private LACountyTrigger laCountyTrigger;
+  private NonLACountyTriggers nonLaTriggers;
   private StaffPersonIdRetriever staffPersonIdRetriever;
 
   /**
@@ -53,16 +55,19 @@ public class ClientAddressService implements CrudsService {
    * @param staffpersonDao The {@link Dao} handling
    *        {@link gov.ca.cwds.data.persistence.cms.StaffPerson} objects
    * @param staffPersonIdRetriever the staffPersonIdRetriever
+   * @param nonLaTriggers The {@link Dao} handling
+   *        {@link gov.ca.cwds.rest.business.rules.NonLACountyTriggers} objects.
    */
   @Inject
   public ClientAddressService(ClientAddressDao clientAddressDao, StaffPersonDao staffpersonDao,
       TriggerTablesDao triggerTablesDao, LACountyTrigger laCountyTrigger,
-      StaffPersonIdRetriever staffPersonIdRetriever) {
+      StaffPersonIdRetriever staffPersonIdRetriever, NonLACountyTriggers nonLaTriggers) {
     this.clientAddressDao = clientAddressDao;
     this.staffpersonDao = staffpersonDao;
     this.triggerTablesDao = triggerTablesDao;
     this.laCountyTrigger = laCountyTrigger;
     this.staffPersonIdRetriever = staffPersonIdRetriever;
+    this.nonLaTriggers = nonLaTriggers;
   }
 
   @Override
@@ -158,6 +163,8 @@ public class ClientAddressService implements CrudsService {
       if (staffperson != null
           && (triggerTablesDao.getLaCountySpecificCode().equals(staffperson.getCountyCode()))) {
         laCountyTrigger.createClientAddressCountyTrigger(managedClientAddress);
+      } else {
+        nonLaTriggers.createAndUpdateClientAddressCoutyOwnership(managedClientAddress);
       }
       managedClientAddress = clientAddressDao.create(managedClientAddress);
       return new gov.ca.cwds.rest.api.domain.cms.ClientAddress(managedClientAddress, false);

--- a/src/test/java/gov/ca/cwds/fixture/ReferralClientResourceBuilder.java
+++ b/src/test/java/gov/ca/cwds/fixture/ReferralClientResourceBuilder.java
@@ -1,0 +1,186 @@
+package gov.ca.cwds.fixture;
+
+import gov.ca.cwds.rest.api.domain.cms.ReferralClient;
+
+/**
+ * 
+ * @author CWDS API Team
+ */
+@SuppressWarnings("javadoc")
+public class ReferralClientResourceBuilder {
+
+  String approvalNumber = "123456789A";
+  Short approvalStatusType = (short) 1234;
+  Short dispositionClosureReasonType = (short) 7890;
+  String dispositionCode = "S";
+  String dispositionDate = "2000-01-01";
+  Boolean selfReportedIndicator = false;
+  Boolean staffPersonAddedIndicator = false;
+  String referralId = "ABC1234567";
+  String clientId = "1234567ABC";
+  String dispositionClosureDescription = "Some type of Kili Kili descrption";
+  Short ageNumber = (short) 25;
+  String agePeriodCode = "D";
+  String countySpecificCode = "99";
+  Boolean mentalHealthIssuesIndicator = false;
+  Boolean alcoholIndicator = false;
+  Boolean drugIndicator = false;
+
+  public ReferralClient buildReferralClient() {
+    return new ReferralClient(approvalNumber, approvalStatusType, dispositionClosureReasonType,
+        dispositionCode, dispositionDate, selfReportedIndicator, staffPersonAddedIndicator,
+        referralId, clientId, dispositionClosureDescription, ageNumber, agePeriodCode,
+        countySpecificCode, mentalHealthIssuesIndicator, alcoholIndicator, drugIndicator);
+  }
+
+  public String getApprovalNumber() {
+    return approvalNumber;
+  }
+
+  public ReferralClientResourceBuilder setApprovalNumber(String approvalNumber) {
+    this.approvalNumber = approvalNumber;
+    return this;
+  }
+
+  public Short getApprovalStatusType() {
+    return approvalStatusType;
+  }
+
+  public ReferralClientResourceBuilder setApprovalStatusType(Short approvalStatusType) {
+    this.approvalStatusType = approvalStatusType;
+    return this;
+  }
+
+  public Short getDispositionClosureReasonType() {
+    return dispositionClosureReasonType;
+  }
+
+  public ReferralClientResourceBuilder setDispositionClosureReasonType(
+      Short dispositionClosureReasonType) {
+    this.dispositionClosureReasonType = dispositionClosureReasonType;
+    return this;
+  }
+
+  public String getDispositionCode() {
+    return dispositionCode;
+  }
+
+  public ReferralClientResourceBuilder setDispositionCode(String dispositionCode) {
+    this.dispositionCode = dispositionCode;
+    return this;
+  }
+
+  public String getDispositionDate() {
+    return dispositionDate;
+  }
+
+  public ReferralClientResourceBuilder setDispositionDate(String dispositionDate) {
+    this.dispositionDate = dispositionDate;
+    return this;
+  }
+
+  public Boolean getSelfReportedIndicator() {
+    return selfReportedIndicator;
+  }
+
+  public ReferralClientResourceBuilder setSelfReportedIndicator(Boolean selfReportedIndicator) {
+    this.selfReportedIndicator = selfReportedIndicator;
+    return this;
+  }
+
+  public Boolean getStaffPersonAddedIndicator() {
+    return staffPersonAddedIndicator;
+  }
+
+  public ReferralClientResourceBuilder setStaffPersonAddedIndicator(
+      Boolean staffPersonAddedIndicator) {
+    this.staffPersonAddedIndicator = staffPersonAddedIndicator;
+    return this;
+  }
+
+  public String getReferralId() {
+    return referralId;
+  }
+
+  public ReferralClientResourceBuilder setReferralId(String referralId) {
+    this.referralId = referralId;
+    return this;
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public ReferralClientResourceBuilder setClientId(String clientId) {
+    this.clientId = clientId;
+    return this;
+  }
+
+  public String getDispositionClosureDescription() {
+    return dispositionClosureDescription;
+  }
+
+  public ReferralClientResourceBuilder setDispositionClosureDescription(
+      String dispositionClosureDescription) {
+    this.dispositionClosureDescription = dispositionClosureDescription;
+    return this;
+  }
+
+  public Short getAgeNumber() {
+    return ageNumber;
+  }
+
+  public ReferralClientResourceBuilder setAgeNumber(Short ageNumber) {
+    this.ageNumber = ageNumber;
+    return this;
+  }
+
+  public String getAgePeriodCode() {
+    return agePeriodCode;
+  }
+
+  public ReferralClientResourceBuilder setAgePeriodCode(String agePeriodCode) {
+    this.agePeriodCode = agePeriodCode;
+    return this;
+  }
+
+  public String getCountySpecificCode() {
+    return countySpecificCode;
+  }
+
+  public ReferralClientResourceBuilder setCountySpecificCode(String countySpecificCode) {
+    this.countySpecificCode = countySpecificCode;
+    return this;
+  }
+
+  public Boolean getMentalHealthIssuesIndicator() {
+    return mentalHealthIssuesIndicator;
+  }
+
+  public ReferralClientResourceBuilder setMentalHealthIssuesIndicator(
+      Boolean mentalHealthIssuesIndicator) {
+    this.mentalHealthIssuesIndicator = mentalHealthIssuesIndicator;
+    return this;
+  }
+
+  public Boolean getAlcoholIndicator() {
+    return alcoholIndicator;
+  }
+
+  public ReferralClientResourceBuilder setAlcoholIndicator(Boolean alcoholIndicator) {
+    this.alcoholIndicator = alcoholIndicator;
+    return this;
+  }
+
+  public Boolean getDrugIndicator() {
+    return drugIndicator;
+  }
+
+  public ReferralClientResourceBuilder setDrugIndicator(Boolean drugIndicator) {
+    this.drugIndicator = drugIndicator;
+    return this;
+  }
+
+
+
+}

--- a/src/test/java/gov/ca/cwds/rest/business/rules/NonLACountyTriggersTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/NonLACountyTriggersTest.java
@@ -4,11 +4,11 @@ import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -19,9 +19,18 @@ import org.mockito.stubbing.Answer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import gov.ca.cwds.data.cms.CountyOwnershipDao;
+import gov.ca.cwds.data.cms.ReferralClientDao;
+import gov.ca.cwds.data.cms.ReferralDao;
 import gov.ca.cwds.data.persistence.cms.Client;
+import gov.ca.cwds.data.persistence.cms.ClientAddress;
 import gov.ca.cwds.data.persistence.cms.CountyOwnership;
 import gov.ca.cwds.data.persistence.cms.SystemCodeTestHarness;
+import gov.ca.cwds.fixture.AssignmentResourceBuilder;
+import gov.ca.cwds.fixture.ClientAddressResourceBuilder;
+import gov.ca.cwds.fixture.ReferralClientResourceBuilder;
+import gov.ca.cwds.fixture.ReferralResourceBuilder;
+import gov.ca.cwds.rest.api.domain.cms.Assignment;
+import gov.ca.cwds.rest.api.domain.cms.Referral;
 import gov.ca.cwds.rest.api.domain.cms.ReferralClient;
 
 /**
@@ -33,6 +42,8 @@ public class NonLACountyTriggersTest {
   private static final ObjectMapper MAPPER = SystemCodeTestHarness.MAPPER;
 
   private CountyOwnershipDao countyOwnershipDao;
+  private ReferralDao referralDao;
+  private ReferralClientDao referralClientDao;
   private NonLACountyTriggers nonLaCountyTriggers;
 
   private static CountyOwnership countyOwnership;
@@ -47,7 +58,10 @@ public class NonLACountyTriggersTest {
   @Before
   public void setup() throws Exception {
     countyOwnershipDao = mock(CountyOwnershipDao.class);
-    nonLaCountyTriggers = new NonLACountyTriggers(countyOwnershipDao);
+    referralDao = mock(ReferralDao.class);
+    referralClientDao = mock(ReferralClientDao.class);
+    nonLaCountyTriggers =
+        new NonLACountyTriggers(countyOwnershipDao, referralDao, referralClientDao);
     countyOwnership = null;
   }
 
@@ -63,7 +77,7 @@ public class NonLACountyTriggersTest {
     gov.ca.cwds.data.persistence.cms.ReferralClient toCreate =
         new gov.ca.cwds.data.persistence.cms.ReferralClient(referralClientDomain, "ABC");
 
-    ReferralClient request = new ReferralClient(toCreate);
+    // ReferralClient request = new ReferralClient(toCreate);
     when(countyOwnershipDao.find(any(String.class))).thenReturn(null);
     when(countyOwnershipDao.create(any(CountyOwnership.class)))
         .thenAnswer(new Answer<CountyOwnership>() {
@@ -77,7 +91,7 @@ public class NonLACountyTriggersTest {
           }
         });
     nonLaCountyTriggers.createAndUpdateReferralClientCoutyOwnership(toCreate);
-    Assert.assertNotNull(countyOwnership);
+    assertThat(countyOwnership, is(notNullValue()));
     assertThat(countyOwnership.getEntityCode(), is(equalTo("C")));
   }
 
@@ -93,7 +107,7 @@ public class NonLACountyTriggersTest {
     gov.ca.cwds.data.persistence.cms.ReferralClient toCreate =
         new gov.ca.cwds.data.persistence.cms.ReferralClient(referralClientDomain, "ABC");
 
-    ReferralClient request = new ReferralClient(toCreate);
+    // ReferralClient request = new ReferralClient(toCreate);
     when(countyOwnershipDao.find(any(String.class))).thenReturn(new CountyOwnership());
     when(countyOwnershipDao.update(any(CountyOwnership.class)))
         .thenAnswer(new Answer<CountyOwnership>() {
@@ -107,7 +121,7 @@ public class NonLACountyTriggersTest {
           }
         });
     nonLaCountyTriggers.createAndUpdateReferralClientCoutyOwnership(toCreate);
-    Assert.assertNotNull(countyOwnership);
+    assertThat(countyOwnership, is(notNullValue()));
     assertThat(countyOwnership.getCounty62Flag(), is(equalTo("Y")));
   }
 
@@ -116,7 +130,7 @@ public class NonLACountyTriggersTest {
    */
   @SuppressWarnings("javadoc")
   @Test
-  public void testForClientCreatedCountyOwnershipTest() throws Exception {
+  public void testForClientCreatedCountyOwnership() throws Exception {
     gov.ca.cwds.rest.api.domain.cms.Client ClientDomain = MAPPER.readValue(
         fixture("fixtures/legacy/business/rules/nonLaCountyTrigger/clientValid.json"),
         gov.ca.cwds.rest.api.domain.cms.Client.class);
@@ -133,9 +147,151 @@ public class NonLACountyTriggersTest {
           }
         });
     nonLaCountyTriggers.createClientCountyTrigger(toCreate);
-    Assert.assertNotNull(countyOwnership);
+    assertThat(countyOwnership, is(notNullValue()));
     assertThat(countyOwnership.getEntityCode(), is(equalTo("C")));
   }
 
+  /**
+   * Test for ClientAddress CountyOwnership created
+   * 
+   * @throws Exception - exception
+   */
+  @Test
+  public void testForClientAddressCreatedCountyOwnership() throws Exception {
+
+    gov.ca.cwds.rest.api.domain.cms.ClientAddress clientAddressDomain =
+        new ClientAddressResourceBuilder().buildClientAddress();
+    ClientAddress toCreate = new ClientAddress("ABC1234567", clientAddressDomain, "ABC");
+
+    ReferralClient referralClientDomain =
+        new ReferralClientResourceBuilder().setCountySpecificCode("62").buildReferralClient();
+    gov.ca.cwds.data.persistence.cms.ReferralClient referralClient =
+        new gov.ca.cwds.data.persistence.cms.ReferralClient(referralClientDomain, "ABC");
+
+    when(referralClientDao.find(any(String.class))).thenReturn(referralClient);
+    when(countyOwnershipDao.create(any(CountyOwnership.class)))
+        .thenAnswer(new Answer<CountyOwnership>() {
+
+          @Override
+          public CountyOwnership answer(InvocationOnMock invocation) throws Throwable {
+
+            CountyOwnership report = (CountyOwnership) invocation.getArguments()[0];
+            countyOwnership = report;
+            return report;
+          }
+        });
+    nonLaCountyTriggers.createAndUpdateClientAddressCoutyOwnership(toCreate);
+    assertThat(countyOwnership, is(notNullValue()));
+    assertThat(countyOwnership.getEntityCode(), is(equalTo("A")));
+    assertThat(countyOwnership.getCounty62Flag(), is(equalTo("Y")));
+  }
+
+  /**
+   * Test for updating the countyOwnership for the exisiting Address Id
+   * 
+   * @throws Exception - exception
+   */
+  @Test
+  public void testForClientAddressUpdatedCountyOwnership() throws Exception {
+
+    gov.ca.cwds.rest.api.domain.cms.ClientAddress clientAddressDomain =
+        new ClientAddressResourceBuilder().buildClientAddress();
+    ClientAddress toCreate = new ClientAddress("ABC1234567", clientAddressDomain, "ABC");
+
+    ReferralClient referralClientDomain =
+        new ReferralClientResourceBuilder().setCountySpecificCode("54").buildReferralClient();
+    gov.ca.cwds.data.persistence.cms.ReferralClient referralClient =
+        new gov.ca.cwds.data.persistence.cms.ReferralClient(referralClientDomain, "ABC");
+
+    when(referralClientDao.find(any(String.class))).thenReturn(referralClient);
+
+    when(countyOwnershipDao.find(any(String.class))).thenReturn(new CountyOwnership());
+    when(countyOwnershipDao.update(any(CountyOwnership.class)))
+        .thenAnswer(new Answer<CountyOwnership>() {
+
+          @Override
+          public CountyOwnership answer(InvocationOnMock invocation) throws Throwable {
+
+            CountyOwnership report = (CountyOwnership) invocation.getArguments()[0];
+            countyOwnership = report;
+            return report;
+          }
+        });
+
+    nonLaCountyTriggers.createAndUpdateClientAddressCoutyOwnership(toCreate);
+    assertThat(countyOwnership, is(notNullValue()));
+    assertThat(countyOwnership.getCounty54Flag(), is(equalTo("Y")));
+  }
+
+
+  /**
+   * Test for Referral CountyOwnership created
+   * 
+   * @throws Exception - exception
+   */
+  @Test
+  public void testForReferralCreatedCountyOwnership() throws Exception {
+
+    Assignment assignmentDomain = new AssignmentResourceBuilder().buildAssignment();
+    gov.ca.cwds.data.persistence.cms.Assignment toCreate =
+        new gov.ca.cwds.data.persistence.cms.Assignment("ABC1234567", assignmentDomain, "ABC");
+
+    Referral referralClientDomain =
+        new ReferralResourceBuilder().setCountySpecificCode("62").build();
+    gov.ca.cwds.data.persistence.cms.Referral referral =
+        new gov.ca.cwds.data.persistence.cms.Referral("ABC1234567", referralClientDomain, "0X5");
+
+    when(referralDao.find(any(String.class))).thenReturn(referral);
+    when(countyOwnershipDao.create(any(CountyOwnership.class)))
+        .thenAnswer(new Answer<CountyOwnership>() {
+
+          @Override
+          public CountyOwnership answer(InvocationOnMock invocation) throws Throwable {
+
+            CountyOwnership report = (CountyOwnership) invocation.getArguments()[0];
+            countyOwnership = report;
+            return report;
+          }
+        });
+    nonLaCountyTriggers.createAndUpdateReferralCoutyOwnership(toCreate);
+    assertThat(countyOwnership, is(notNullValue()));
+    assertThat(countyOwnership.getEntityCode(), is(equalTo("R")));
+    assertThat(countyOwnership.getCounty62Flag(), is(equalTo("Y")));
+  }
+
+  /**
+   * Test for updating the countyOwnership for the exisiting Referral Id
+   * 
+   * @throws Exception - exception
+   */
+  @Test
+  public void testForReferralUpdatedCountyOwnership() throws Exception {
+
+    Assignment assignmentDomain = new AssignmentResourceBuilder().buildAssignment();
+    gov.ca.cwds.data.persistence.cms.Assignment toCreate =
+        new gov.ca.cwds.data.persistence.cms.Assignment("ABC1234567", assignmentDomain, "ABC");
+
+    Referral referralClientDomain =
+        new ReferralResourceBuilder().setCountySpecificCode("54").build();
+    gov.ca.cwds.data.persistence.cms.Referral referral =
+        new gov.ca.cwds.data.persistence.cms.Referral("ABC1234567", referralClientDomain, "0X5");
+
+    when(referralDao.find(any(String.class))).thenReturn(referral);
+    when(countyOwnershipDao.find(any(String.class))).thenReturn(new CountyOwnership());
+    when(countyOwnershipDao.update(any(CountyOwnership.class)))
+        .thenAnswer(new Answer<CountyOwnership>() {
+
+          @Override
+          public CountyOwnership answer(InvocationOnMock invocation) throws Throwable {
+
+            CountyOwnership report = (CountyOwnership) invocation.getArguments()[0];
+            countyOwnership = report;
+            return report;
+          }
+        });
+    nonLaCountyTriggers.createAndUpdateReferralCoutyOwnership(toCreate);
+    assertThat(countyOwnership, is(notNullValue()));
+    assertThat(countyOwnership.getCounty54Flag(), is(equalTo("Y")));
+  }
 
 }

--- a/src/test/java/gov/ca/cwds/rest/business/rules/NonLACountyTriggersTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/NonLACountyTriggersTest.java
@@ -1,6 +1,5 @@
 package gov.ca.cwds.rest.business.rules;
 
-import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -16,17 +15,16 @@ import org.junit.rules.ExpectedException;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import gov.ca.cwds.data.cms.CountyOwnershipDao;
 import gov.ca.cwds.data.cms.ReferralClientDao;
 import gov.ca.cwds.data.cms.ReferralDao;
 import gov.ca.cwds.data.persistence.cms.Client;
 import gov.ca.cwds.data.persistence.cms.ClientAddress;
 import gov.ca.cwds.data.persistence.cms.CountyOwnership;
-import gov.ca.cwds.data.persistence.cms.SystemCodeTestHarness;
+import gov.ca.cwds.data.rules.TriggerTableException;
 import gov.ca.cwds.fixture.AssignmentResourceBuilder;
 import gov.ca.cwds.fixture.ClientAddressResourceBuilder;
+import gov.ca.cwds.fixture.ClientResourceBuilder;
 import gov.ca.cwds.fixture.ReferralClientResourceBuilder;
 import gov.ca.cwds.fixture.ReferralResourceBuilder;
 import gov.ca.cwds.rest.api.domain.cms.Assignment;
@@ -38,8 +36,6 @@ import gov.ca.cwds.rest.api.domain.cms.ReferralClient;
  *
  */
 public class NonLACountyTriggersTest {
-
-  private static final ObjectMapper MAPPER = SystemCodeTestHarness.MAPPER;
 
   private CountyOwnershipDao countyOwnershipDao;
   private ReferralDao referralDao;
@@ -65,19 +61,19 @@ public class NonLACountyTriggersTest {
     countyOwnership = null;
   }
 
-  /*
+  /**
    * Test for checking the referral Client CountyOnwership created or updated through the PUT method
+   * 
+   * @throws Exception - TriggerTableException
    */
-  @SuppressWarnings("javadoc")
   @Test
   public void testChecksReferralClientCreatedCountyOwnership() throws Exception {
-    ReferralClient referralClientDomain = MAPPER.readValue(
-        fixture("fixtures/legacy/business/rules/nonLaCountyTrigger/referralClientValid.json"),
-        ReferralClient.class);
+    ReferralClient referralClientDomain =
+        new ReferralClientResourceBuilder().setCountySpecificCode("54").buildReferralClient();
+
     gov.ca.cwds.data.persistence.cms.ReferralClient toCreate =
         new gov.ca.cwds.data.persistence.cms.ReferralClient(referralClientDomain, "ABC");
 
-    // ReferralClient request = new ReferralClient(toCreate);
     when(countyOwnershipDao.find(any(String.class))).thenReturn(null);
     when(countyOwnershipDao.create(any(CountyOwnership.class)))
         .thenAnswer(new Answer<CountyOwnership>() {
@@ -95,19 +91,48 @@ public class NonLACountyTriggersTest {
     assertThat(countyOwnership.getEntityCode(), is(equalTo("C")));
   }
 
-  /*
-   * Test for checking the referral Client CountyOnwership updated
+  /**
+   * Test for checking the referral Client CountyOnwership create throws exception
+   * 
+   * @throws Exception - TriggerTableException
    */
-  @SuppressWarnings("javadoc")
-  @Test
-  public void testForReferralClientUpdatedCountyOwnership() throws Exception {
-    ReferralClient referralClientDomain = MAPPER.readValue(
-        fixture("fixtures/legacy/business/rules/nonLaCountyTrigger/referralClientValid.json"),
-        ReferralClient.class);
+  @Test(expected = TriggerTableException.class)
+  public void testChecksReferralClientCreatedCountyOwnershipThrowsTriggerTableException()
+      throws Exception {
+    ReferralClient referralClientDomain =
+        new ReferralClientResourceBuilder().setCountySpecificCode("100").buildReferralClient();
+
     gov.ca.cwds.data.persistence.cms.ReferralClient toCreate =
         new gov.ca.cwds.data.persistence.cms.ReferralClient(referralClientDomain, "ABC");
 
-    // ReferralClient request = new ReferralClient(toCreate);
+    when(countyOwnershipDao.find(any(String.class))).thenReturn(null);
+    when(countyOwnershipDao.create(any(CountyOwnership.class)))
+        .thenAnswer(new Answer<CountyOwnership>() {
+
+          @Override
+          public CountyOwnership answer(InvocationOnMock invocation) throws Throwable {
+
+            CountyOwnership report = (CountyOwnership) invocation.getArguments()[0];
+            countyOwnership = report;
+            return report;
+          }
+        });
+    nonLaCountyTriggers.createAndUpdateReferralClientCoutyOwnership(toCreate);
+  }
+
+  /**
+   * Test for checking the referral Client CountyOnwership updated
+   * 
+   * @throws Exception - TriggerTableException
+   */
+  @Test
+  public void testForReferralClientUpdatedCountyOwnership() throws Exception {
+    ReferralClient referralClientDomain =
+        new ReferralClientResourceBuilder().setCountySpecificCode("62").buildReferralClient();
+
+    gov.ca.cwds.data.persistence.cms.ReferralClient toCreate =
+        new gov.ca.cwds.data.persistence.cms.ReferralClient(referralClientDomain, "ABC");
+
     when(countyOwnershipDao.find(any(String.class))).thenReturn(new CountyOwnership());
     when(countyOwnershipDao.update(any(CountyOwnership.class)))
         .thenAnswer(new Answer<CountyOwnership>() {
@@ -125,15 +150,15 @@ public class NonLACountyTriggersTest {
     assertThat(countyOwnership.getCounty62Flag(), is(equalTo("Y")));
   }
 
-  /*
+  /**
    * Test for checking the Client CountyOnwership created
+   * 
+   * @throws Exception - TriggerTableException
    */
-  @SuppressWarnings("javadoc")
   @Test
   public void testForClientCreatedCountyOwnership() throws Exception {
-    gov.ca.cwds.rest.api.domain.cms.Client ClientDomain = MAPPER.readValue(
-        fixture("fixtures/legacy/business/rules/nonLaCountyTrigger/clientValid.json"),
-        gov.ca.cwds.rest.api.domain.cms.Client.class);
+    gov.ca.cwds.rest.api.domain.cms.Client ClientDomain = new ClientResourceBuilder().build();
+
     Client toCreate = new Client("ABC1234567", ClientDomain, "ABC");
     when(countyOwnershipDao.create(any(CountyOwnership.class)))
         .thenAnswer(new Answer<CountyOwnership>() {
@@ -154,7 +179,7 @@ public class NonLACountyTriggersTest {
   /**
    * Test for ClientAddress CountyOwnership created
    * 
-   * @throws Exception - exception
+   * @throws Exception - TriggerTableException
    */
   @Test
   public void testForClientAddressCreatedCountyOwnership() throws Exception {
@@ -186,10 +211,44 @@ public class NonLACountyTriggersTest {
     assertThat(countyOwnership.getCounty62Flag(), is(equalTo("Y")));
   }
 
+
+  /**
+   * Test for clientAddress CountyOwnership creation throws TriggerTableException
+   * 
+   * @throws Exception - TriggerTableException
+   */
+  @Test(expected = TriggerTableException.class)
+  public void testForClientAddressCreatedCountyOwnershipThrowsTriggerTableException()
+      throws Exception {
+
+    gov.ca.cwds.rest.api.domain.cms.ClientAddress clientAddressDomain =
+        new ClientAddressResourceBuilder().buildClientAddress();
+    ClientAddress toCreate = new ClientAddress("ABC1234567", clientAddressDomain, "ABC");
+
+    ReferralClient referralClientDomain =
+        new ReferralClientResourceBuilder().setCountySpecificCode("100").buildReferralClient();
+    gov.ca.cwds.data.persistence.cms.ReferralClient referralClient =
+        new gov.ca.cwds.data.persistence.cms.ReferralClient(referralClientDomain, "ABC");
+
+    when(referralClientDao.find(any(String.class))).thenReturn(referralClient);
+    when(countyOwnershipDao.create(any(CountyOwnership.class)))
+        .thenAnswer(new Answer<CountyOwnership>() {
+
+          @Override
+          public CountyOwnership answer(InvocationOnMock invocation) throws Throwable {
+
+            CountyOwnership report = (CountyOwnership) invocation.getArguments()[0];
+            countyOwnership = report;
+            return report;
+          }
+        });
+    nonLaCountyTriggers.createAndUpdateClientAddressCoutyOwnership(toCreate);
+  }
+
   /**
    * Test for updating the countyOwnership for the exisiting Address Id
    * 
-   * @throws Exception - exception
+   * @throws Exception - TriggerTableException
    */
   @Test
   public void testForClientAddressUpdatedCountyOwnership() throws Exception {
@@ -227,7 +286,7 @@ public class NonLACountyTriggersTest {
   /**
    * Test for Referral CountyOwnership created
    * 
-   * @throws Exception - exception
+   * @throws Exception - TriggerTableException
    */
   @Test
   public void testForReferralCreatedCountyOwnership() throws Exception {
@@ -260,9 +319,39 @@ public class NonLACountyTriggersTest {
   }
 
   /**
+   * @throws Exception - TriggerTableException
+   */
+  @Test(expected = TriggerTableException.class)
+  public void testForReferralCreatedCountyOwnershipThrowsTriggerTableException() throws Exception {
+
+    Assignment assignmentDomain = new AssignmentResourceBuilder().buildAssignment();
+    gov.ca.cwds.data.persistence.cms.Assignment toCreate =
+        new gov.ca.cwds.data.persistence.cms.Assignment("ABC1234567", assignmentDomain, "ABC");
+
+    Referral referralClientDomain =
+        new ReferralResourceBuilder().setCountySpecificCode("100").build();
+    gov.ca.cwds.data.persistence.cms.Referral referral =
+        new gov.ca.cwds.data.persistence.cms.Referral("ABC1234567", referralClientDomain, "0X5");
+
+    when(referralDao.find(any(String.class))).thenReturn(referral);
+    when(countyOwnershipDao.create(any(CountyOwnership.class)))
+        .thenAnswer(new Answer<CountyOwnership>() {
+
+          @Override
+          public CountyOwnership answer(InvocationOnMock invocation) throws Throwable {
+
+            CountyOwnership report = (CountyOwnership) invocation.getArguments()[0];
+            countyOwnership = report;
+            return report;
+          }
+        });
+    nonLaCountyTriggers.createAndUpdateReferralCoutyOwnership(toCreate);
+  }
+
+  /**
    * Test for updating the countyOwnership for the exisiting Referral Id
    * 
-   * @throws Exception - exception
+   * @throws Exception - TriggerTableException
    */
   @Test
   public void testForReferralUpdatedCountyOwnership() throws Exception {

--- a/src/test/java/gov/ca/cwds/rest/business/rules/RemindersTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/RemindersTest.java
@@ -6,12 +6,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import gov.ca.cwds.fixture.ReferralResourceBuilder;
-import gov.ca.cwds.rest.messages.MessageBuilder;
-import gov.ca.cwds.rest.resources.cms.ReferralResource;
-import gov.ca.cwds.rest.services.cms.ReferralService;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -28,8 +23,8 @@ import gov.ca.cwds.data.cms.ReporterDao;
 import gov.ca.cwds.fixture.AddressResourceBuilder;
 import gov.ca.cwds.fixture.AllegationResourceBuilder;
 import gov.ca.cwds.fixture.CrossReportResourceBuilder;
-import gov.ca.cwds.fixture.MockedScreeningToReferralServiceBuilder;
 import gov.ca.cwds.fixture.ParticipantResourceBuilder;
+import gov.ca.cwds.fixture.ReferralResourceBuilder;
 import gov.ca.cwds.fixture.ScreeningToReferralResourceBuilder;
 import gov.ca.cwds.rest.api.domain.Address;
 import gov.ca.cwds.rest.api.domain.Allegation;
@@ -49,7 +44,6 @@ import gov.ca.cwds.rest.services.cms.TickleService;
 public class RemindersTest {
 
   private TickleService tickleService;
-  private ReferralService referralService;
   private ClientDao clientDao;
   private ReferralDao referralDao;
   private AllegationDao allegationDao;
@@ -72,7 +66,6 @@ public class RemindersTest {
   @Before
   public void setup() throws Exception {
     tickleService = mock(TickleService.class);
-    referralService = mock(ReferralService.class);
     clientDao = mock(ClientDao.class);
     referralDao = mock(ReferralDao.class);
     allegationDao = mock(AllegationDao.class);
@@ -103,10 +96,8 @@ public class RemindersTest {
     PostedScreeningToReferral postedScreeningToReferral = PostedScreeningToReferral
         .createWithDefaults("123ABC1234", referral, participants, crossReports, allegations);
 
-    Referral domainReferral = new ReferralResourceBuilder()
-        .setReceivedDate("2016-09-02")
-        .setReceivedTime("13:00:00")
-        .build();
+    Referral domainReferral = new ReferralResourceBuilder().setReceivedDate("2016-09-02")
+        .setReceivedTime("13:00:00").build();
 
     gov.ca.cwds.data.persistence.cms.Referral savedReferral =
         new gov.ca.cwds.data.persistence.cms.Referral("123ABC1235", domainReferral, "0X5");
@@ -166,10 +157,8 @@ public class RemindersTest {
     PostedScreeningToReferral postedScreeningToReferral = PostedScreeningToReferral
         .createWithDefaults("123ABC1234", referral, participants, crossReports, allegations);
 
-    Referral domainReferral = new ReferralResourceBuilder()
-        .setReceivedDate("2016-09-02")
-        .setReceivedTime("13:00:00")
-        .build();
+    Referral domainReferral = new ReferralResourceBuilder().setReceivedDate("2016-09-02")
+        .setReceivedTime("13:00:00").build();
 
     gov.ca.cwds.data.persistence.cms.Referral savedReferral =
         new gov.ca.cwds.data.persistence.cms.Referral("123ABC1235", domainReferral, "0X5");
@@ -228,10 +217,8 @@ public class RemindersTest {
     PostedScreeningToReferral postedScreeningToReferral = PostedScreeningToReferral
         .createWithDefaults("123ABC1234", referral, participants, crossReports, allegations);
 
-    Referral domainReferral = new ReferralResourceBuilder()
-        .setReceivedDate("2016-09-02")
-        .setReceivedTime("13:00:00")
-        .build();
+    Referral domainReferral = new ReferralResourceBuilder().setReceivedDate("2016-09-02")
+        .setReceivedTime("13:00:00").build();
 
     gov.ca.cwds.data.persistence.cms.Referral savedReferral =
         new gov.ca.cwds.data.persistence.cms.Referral("123ABC1235", domainReferral, "0X5");
@@ -291,10 +278,8 @@ public class RemindersTest {
     PostedScreeningToReferral postedScreeningToReferral = PostedScreeningToReferral
         .createWithDefaults("123ABC1234", referral, participants, crossReports, allegations);
 
-    Referral domainReferral = new ReferralResourceBuilder()
-        .setReceivedDate("2016-09-02")
-        .setReceivedTime("13:00:00")
-        .build();
+    Referral domainReferral = new ReferralResourceBuilder().setReceivedDate("2016-09-02")
+        .setReceivedTime("13:00:00").build();
 
     gov.ca.cwds.data.persistence.cms.Referral savedReferral =
         new gov.ca.cwds.data.persistence.cms.Referral("123ABC1235", domainReferral, "0X5");
@@ -362,10 +347,8 @@ public class RemindersTest {
     PostedScreeningToReferral postedScreeningToReferral = PostedScreeningToReferral
         .createWithDefaults("123ABC1234", referral, participants, crossReports, allegations);
 
-    Referral domainReferral = new ReferralResourceBuilder()
-        .setReceivedDate("2016-09-02")
-        .setReceivedTime("13:00:00")
-        .build();
+    Referral domainReferral = new ReferralResourceBuilder().setReceivedDate("2016-09-02")
+        .setReceivedTime("13:00:00").build();
 
     gov.ca.cwds.data.persistence.cms.Referral savedReferral =
         new gov.ca.cwds.data.persistence.cms.Referral("123ABC1235", domainReferral, "0X5");
@@ -433,10 +416,8 @@ public class RemindersTest {
     PostedScreeningToReferral postedScreeningToReferral = PostedScreeningToReferral
         .createWithDefaults("123ABC1234", referral, participants, crossReports, allegations);
 
-    Referral domainReferral = new ReferralResourceBuilder()
-        .setReceivedDate("2016-09-02")
-        .setReceivedTime("13:00:00")
-        .build();
+    Referral domainReferral = new ReferralResourceBuilder().setReceivedDate("2016-09-02")
+        .setReceivedTime("13:00:00").build();
 
     gov.ca.cwds.data.persistence.cms.Referral savedReferral =
         new gov.ca.cwds.data.persistence.cms.Referral("123ABC1235", domainReferral, "0X5");
@@ -504,10 +485,8 @@ public class RemindersTest {
     PostedScreeningToReferral postedScreeningToReferral = PostedScreeningToReferral
         .createWithDefaults("123ABC1234", referral, participants, crossReports, allegations);
 
-    Referral domainReferral = new ReferralResourceBuilder()
-        .setReceivedDate("2016-09-02")
-        .setReceivedTime("13:00:00")
-        .build();
+    Referral domainReferral = new ReferralResourceBuilder().setReceivedDate("2016-09-02")
+        .setReceivedTime("13:00:00").build();
 
     gov.ca.cwds.data.persistence.cms.Referral savedReferral =
         new gov.ca.cwds.data.persistence.cms.Referral("123ABC1235", domainReferral, "0X5");
@@ -575,10 +554,8 @@ public class RemindersTest {
     PostedScreeningToReferral postedScreeningToReferral = PostedScreeningToReferral
         .createWithDefaults("123ABC1234", referral, participants, crossReports, allegations);
 
-    Referral domainReferral = new ReferralResourceBuilder()
-        .setReceivedDate("2016-09-02")
-        .setReceivedTime("13:00:00")
-        .build();
+    Referral domainReferral = new ReferralResourceBuilder().setReceivedDate("2016-09-02")
+        .setReceivedTime("13:00:00").build();
 
     gov.ca.cwds.data.persistence.cms.Referral savedReferral =
         new gov.ca.cwds.data.persistence.cms.Referral("123ABC1235", domainReferral, "0X5");
@@ -646,10 +623,8 @@ public class RemindersTest {
     PostedScreeningToReferral postedScreeningToReferral = PostedScreeningToReferral
         .createWithDefaults("123ABC1234", referral, participants, crossReports, allegations);
 
-    Referral domainReferral = new ReferralResourceBuilder()
-        .setReceivedDate("2016-09-02")
-        .setReceivedTime("13:00:00")
-        .build();
+    Referral domainReferral = new ReferralResourceBuilder().setReceivedDate("2016-09-02")
+        .setReceivedTime("13:00:00").build();
 
     gov.ca.cwds.data.persistence.cms.Referral savedReferral =
         new gov.ca.cwds.data.persistence.cms.Referral("123ABC1235", domainReferral, "0X5");

--- a/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R00796ScreeningToReferralDeleteTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R00796ScreeningToReferralDeleteTest.java
@@ -4,8 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
 import javax.validation.Validation;
-
 import javax.validation.Validator;
+
 import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Before;
 import org.junit.Rule;
@@ -141,15 +141,16 @@ public class R00796ScreeningToReferralDeleteTest {
     reporterService = new ReporterService(reporterDao, staffPersonIdRetriever);
 
     addressDao = mock(AddressDao.class);
-    addressService =
-        new AddressService(addressDao, staffPersonIdRetriever, ssaName3Dao, upperCaseTables, validator);
+    addressService = new AddressService(addressDao, staffPersonIdRetriever, ssaName3Dao,
+        upperCaseTables, validator);
 
     clientAddressDao = mock(ClientAddressDao.class);
     laCountyTrigger = mock(LACountyTrigger.class);
     triggerTablesDao = mock(TriggerTablesDao.class);
     staffpersonDao = mock(StaffPersonDao.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
     clientAddressService = new ClientAddressService(clientAddressDao, staffpersonDao,
-        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever);
+        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever, nonLACountyTriggers);
 
     longTextDao = mock(LongTextDao.class);
     longTextService = new LongTextService(longTextDao, staffPersonIdRetriever);
@@ -158,15 +159,19 @@ public class R00796ScreeningToReferralDeleteTest {
     childClientService = new ChildClientService(childClientDao, staffPersonIdRetriever);
 
     assignmentDao = mock(AssignmentDao.class);
-    assignmentService = new AssignmentService(assignmentDao, staffPersonIdRetriever, validator);
+    staffpersonDao = mock(StaffPersonDao.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
+    triggerTablesDao = mock(TriggerTablesDao.class);
+    assignmentService = new AssignmentService(assignmentDao, nonLACountyTriggers, staffpersonDao,
+        triggerTablesDao, staffPersonIdRetriever, validator);
 
     reminders = mock(Reminders.class);
 
     screeningToReferralService = new ScreeningToReferralService(referralService, clientService,
         allegationService, crossReportService, referralClientService, reporterService,
-        addressService, clientAddressService, childClientService,
-        assignmentService, Validation.buildDefaultValidatorFactory().getValidator(), referralDao,
-        new MessageBuilder(), allegationPerpetratorHistoryService, reminders);
+        addressService, clientAddressService, childClientService, assignmentService,
+        Validation.buildDefaultValidatorFactory().getValidator(), referralDao, new MessageBuilder(),
+        allegationPerpetratorHistoryService, reminders);
   }
 
   /**

--- a/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R04537FirstResponseDeterminedByStaffPersonIdTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R04537FirstResponseDeterminedByStaffPersonIdTest.java
@@ -8,12 +8,11 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import gov.ca.cwds.fixture.ReferralResourceBuilder;
 import java.util.Set;
 
 import javax.validation.Validation;
-
 import javax.validation.Validator;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -177,15 +176,16 @@ public class R04537FirstResponseDeterminedByStaffPersonIdTest {
     reporterService = new ReporterService(reporterDao, staffPersonIdRetriever);
 
     addressDao = mock(AddressDao.class);
-    addressService =
-        new AddressService(addressDao, staffPersonIdRetriever, ssaName3Dao, upperCaseTables, validator);
+    addressService = new AddressService(addressDao, staffPersonIdRetriever, ssaName3Dao,
+        upperCaseTables, validator);
 
     clientAddressDao = mock(ClientAddressDao.class);
     laCountyTrigger = mock(LACountyTrigger.class);
     triggerTablesDao = mock(TriggerTablesDao.class);
     staffpersonDao = mock(StaffPersonDao.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
     clientAddressService = new ClientAddressService(clientAddressDao, staffpersonDao,
-        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever);
+        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever, nonLACountyTriggers);
 
     longTextDao = mock(LongTextDao.class);
     longTextService = new LongTextService(longTextDao, staffPersonIdRetriever);
@@ -197,7 +197,11 @@ public class R04537FirstResponseDeterminedByStaffPersonIdTest {
     childClientService = new ChildClientService(childClientDao, staffPersonIdRetriever);
 
     assignmentDao = mock(AssignmentDao.class);
-    assignmentService = new AssignmentService(assignmentDao, staffPersonIdRetriever, validator);
+    staffpersonDao = mock(StaffPersonDao.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
+    triggerTablesDao = mock(TriggerTablesDao.class);
+    assignmentService = new AssignmentService(assignmentDao, nonLACountyTriggers, staffpersonDao,
+        triggerTablesDao, staffPersonIdRetriever, validator);
 
     reminders = mock(Reminders.class);
 
@@ -207,9 +211,8 @@ public class R04537FirstResponseDeterminedByStaffPersonIdTest {
 
     screeningToReferralService = new ScreeningToReferralService(referralService, clientService,
         allegationService, crossReportService, referralClientService, reporterService,
-        addressService, clientAddressService, childClientService,
-        assignmentService, validator, referralDao,
-        new MessageBuilder(), allegationPerpetratorHistoryService, reminders);
+        addressService, clientAddressService, childClientService, assignmentService, validator,
+        referralDao, new MessageBuilder(), allegationPerpetratorHistoryService, reminders);
   }
 
   /**

--- a/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R05360ReferralCityMandatoryTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R05360ReferralCityMandatoryTest.java
@@ -11,8 +11,8 @@ import static org.mockito.Mockito.when;
 import java.util.Set;
 
 import javax.validation.Validation;
-
 import javax.validation.Validator;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -167,18 +167,23 @@ public class R05360ReferralCityMandatoryTest {
     reporterService = new ReporterService(reporterDao, staffPersonIdRetriever);
 
     addressDao = mock(AddressDao.class);
-    addressService =
-        new AddressService(addressDao, staffPersonIdRetriever, ssaName3Dao, upperCaseTables, validator);
+    addressService = new AddressService(addressDao, staffPersonIdRetriever, ssaName3Dao,
+        upperCaseTables, validator);
 
     assignmentDao = mock(AssignmentDao.class);
-    assignmentService = new AssignmentService(assignmentDao, staffPersonIdRetriever, validator);
+    staffpersonDao = mock(StaffPersonDao.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
+    triggerTablesDao = mock(TriggerTablesDao.class);
+    assignmentService = new AssignmentService(assignmentDao, nonLACountyTriggers, staffpersonDao,
+        triggerTablesDao, staffPersonIdRetriever, validator);
 
     clientAddressDao = mock(ClientAddressDao.class);
     laCountyTrigger = mock(LACountyTrigger.class);
     triggerTablesDao = mock(TriggerTablesDao.class);
     staffpersonDao = mock(StaffPersonDao.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
     clientAddressService = new ClientAddressService(clientAddressDao, staffpersonDao,
-        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever);
+        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever, nonLACountyTriggers);
 
     longTextDao = mock(LongTextDao.class);
     longTextService = new LongTextService(longTextDao, staffPersonIdRetriever);
@@ -197,9 +202,9 @@ public class R05360ReferralCityMandatoryTest {
 
     screeningToReferralService = new ScreeningToReferralService(referralService, clientService,
         allegationService, crossReportService, referralClientService, reporterService,
-        addressService, clientAddressService, childClientService,
-        assignmentService, Validation.buildDefaultValidatorFactory().getValidator(), referralDao,
-        new MessageBuilder(), allegationPerpetratorHistoryService, reminders);
+        addressService, clientAddressService, childClientService, assignmentService,
+        Validation.buildDefaultValidatorFactory().getValidator(), referralDao, new MessageBuilder(),
+        allegationPerpetratorHistoryService, reminders);
   }
 
   /**

--- a/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R05914DoNotUpdateApprovalStatusTypeTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R05914DoNotUpdateApprovalStatusTypeTest.java
@@ -8,10 +8,9 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.inject.spi.Message;
 import javax.validation.Validation;
-
 import javax.validation.Validator;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -133,8 +132,8 @@ public class R05914DoNotUpdateApprovalStatusTypeTest {
     drmsDocumentService = new DrmsDocumentService(drmsDocumentDao, staffPersonIdRetriever);
 
     addressDao = mock(AddressDao.class);
-    addressService =
-        new AddressService(addressDao, staffPersonIdRetriever, ssaName3Dao, upperCaseTables, validator);
+    addressService = new AddressService(addressDao, staffPersonIdRetriever, ssaName3Dao,
+        upperCaseTables, validator);
 
     referralService = new ReferralService(referralDao, nonLACountyTriggers, laCountyTrigger,
         triggerTablesDao, staffpersonDao, staffPersonIdRetriever, assignmentService, validator,
@@ -173,22 +172,27 @@ public class R05914DoNotUpdateApprovalStatusTypeTest {
     laCountyTrigger = mock(LACountyTrigger.class);
     triggerTablesDao = mock(TriggerTablesDao.class);
     staffpersonDao = mock(StaffPersonDao.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
     clientAddressService = new ClientAddressService(clientAddressDao, staffpersonDao,
-        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever);
+        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever, nonLACountyTriggers);
 
     childClientDao = mock(ChildClientDao.class);
     childClientService = new ChildClientService(childClientDao, staffPersonIdRetriever);
 
     assignmentDao = mock(AssignmentDao.class);
-    assignmentService = new AssignmentService(assignmentDao, staffPersonIdRetriever, validator);
+    staffpersonDao = mock(StaffPersonDao.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
+    triggerTablesDao = mock(TriggerTablesDao.class);
+    assignmentService = new AssignmentService(assignmentDao, nonLACountyTriggers, staffpersonDao,
+        triggerTablesDao, staffPersonIdRetriever, validator);
 
     reminders = mock(Reminders.class);
 
     screeningToReferralService = new ScreeningToReferralService(referralService, clientService,
         allegationService, crossReportService, referralClientService, reporterService,
-        addressService, clientAddressService, childClientService,
-        assignmentService, Validation.buildDefaultValidatorFactory().getValidator(), referralDao,
-        new MessageBuilder(), allegationPerpetratorHistoryService, reminders);
+        addressService, clientAddressService, childClientService, assignmentService,
+        Validation.buildDefaultValidatorFactory().getValidator(), referralDao, new MessageBuilder(),
+        allegationPerpetratorHistoryService, reminders);
 
   }
 
@@ -227,8 +231,8 @@ public class R05914DoNotUpdateApprovalStatusTypeTest {
     when(drmsDocumentDao.create(any(gov.ca.cwds.data.persistence.cms.DrmsDocument.class)))
         .thenReturn(drmsDocumentToCreate);
 
-    Referral referralCreated = referralService.createReferralWithDefaults(
-        screeningToReferral, "2016-08-03T01:00:00.000Z", "2016-08-03T01:00:00.000Z", null, new MessageBuilder());
+    Referral referralCreated = referralService.createReferralWithDefaults(screeningToReferral,
+        "2016-08-03T01:00:00.000Z", "2016-08-03T01:00:00.000Z", null, new MessageBuilder());
     System.out.println(referralCreated.getApprovalStatusType());
     assertThat(referralCreated.getApprovalStatusType(), is(equalTo((short) 118)));
   }

--- a/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R06224DontAllowBlanksInReferralStartDateAndTimeTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R06224DontAllowBlanksInReferralStartDateAndTimeTest.java
@@ -11,8 +11,8 @@ import static org.mockito.Mockito.when;
 import java.util.Set;
 
 import javax.validation.Validation;
-
 import javax.validation.Validator;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -165,15 +165,16 @@ public class R06224DontAllowBlanksInReferralStartDateAndTimeTest {
     reporterService = new ReporterService(reporterDao, staffPersonIdRetriever);
 
     addressDao = mock(AddressDao.class);
-    addressService =
-        new AddressService(addressDao, staffPersonIdRetriever, ssaName3Dao, upperCaseTables, validator);
+    addressService = new AddressService(addressDao, staffPersonIdRetriever, ssaName3Dao,
+        upperCaseTables, validator);
 
     clientAddressDao = mock(ClientAddressDao.class);
     laCountyTrigger = mock(LACountyTrigger.class);
     triggerTablesDao = mock(TriggerTablesDao.class);
     staffpersonDao = mock(StaffPersonDao.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
     clientAddressService = new ClientAddressService(clientAddressDao, staffpersonDao,
-        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever);
+        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever, nonLACountyTriggers);
 
     longTextDao = mock(LongTextDao.class);
     longTextService = new LongTextService(longTextDao, staffPersonIdRetriever);
@@ -185,7 +186,11 @@ public class R06224DontAllowBlanksInReferralStartDateAndTimeTest {
     childClientService = new ChildClientService(childClientDao, staffPersonIdRetriever);
 
     assignmentDao = mock(AssignmentDao.class);
-    assignmentService = new AssignmentService(assignmentDao, staffPersonIdRetriever, validator);
+    staffpersonDao = mock(StaffPersonDao.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
+    triggerTablesDao = mock(TriggerTablesDao.class);
+    assignmentService = new AssignmentService(assignmentDao, nonLACountyTriggers, staffpersonDao,
+        triggerTablesDao, staffPersonIdRetriever, validator);
 
     reminders = mock(Reminders.class);
 
@@ -194,9 +199,9 @@ public class R06224DontAllowBlanksInReferralStartDateAndTimeTest {
         drmsDocumentService, addressService, longTextService);
     screeningToReferralService = new ScreeningToReferralService(referralService, clientService,
         allegationService, crossReportService, referralClientService, reporterService,
-        addressService, clientAddressService, childClientService,
-        assignmentService, Validation.buildDefaultValidatorFactory().getValidator(), referralDao,
-        new MessageBuilder(), allegationPerpetratorHistoryService, reminders);
+        addressService, clientAddressService, childClientService, assignmentService,
+        Validation.buildDefaultValidatorFactory().getValidator(), referralDao, new MessageBuilder(),
+        allegationPerpetratorHistoryService, reminders);
 
   }
 

--- a/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R07577CreateDummyDocsForReferralTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R07577CreateDummyDocsForReferralTest.java
@@ -11,8 +11,8 @@ import static org.mockito.Mockito.when;
 import java.util.Set;
 
 import javax.validation.Validation;
-
 import javax.validation.Validator;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -171,15 +171,16 @@ public class R07577CreateDummyDocsForReferralTest {
     reporterService = new ReporterService(reporterDao, staffPersonIdRetriever);
 
     addressDao = mock(AddressDao.class);
-    addressService =
-        new AddressService(addressDao, staffPersonIdRetriever, ssaName3Dao, upperCaseTables, validator);
+    addressService = new AddressService(addressDao, staffPersonIdRetriever, ssaName3Dao,
+        upperCaseTables, validator);
 
     clientAddressDao = mock(ClientAddressDao.class);
     laCountyTrigger = mock(LACountyTrigger.class);
     triggerTablesDao = mock(TriggerTablesDao.class);
     staffpersonDao = mock(StaffPersonDao.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
     clientAddressService = new ClientAddressService(clientAddressDao, staffpersonDao,
-        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever);
+        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever, nonLACountyTriggers);
 
     longTextDao = mock(LongTextDao.class);
     longTextService = new LongTextService(longTextDao, staffPersonIdRetriever);
@@ -191,7 +192,12 @@ public class R07577CreateDummyDocsForReferralTest {
     childClientService = new ChildClientService(childClientDao, staffPersonIdRetriever);
 
     assignmentDao = mock(AssignmentDao.class);
-    assignmentService = new AssignmentService(assignmentDao, staffPersonIdRetriever, validator);
+    staffpersonDao = mock(StaffPersonDao.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
+    triggerTablesDao = mock(TriggerTablesDao.class);
+    assignmentService = new AssignmentService(assignmentDao, nonLACountyTriggers, staffpersonDao,
+        triggerTablesDao, staffPersonIdRetriever, validator);
+
 
     reminders = mock(Reminders.class);
 
@@ -201,9 +207,9 @@ public class R07577CreateDummyDocsForReferralTest {
 
     screeningToReferralService = new ScreeningToReferralService(referralService, clientService,
         allegationService, crossReportService, referralClientService, reporterService,
-        addressService, clientAddressService, childClientService,
-        assignmentService, Validation.buildDefaultValidatorFactory().getValidator(), referralDao,
-        new MessageBuilder(), allegationPerpetratorHistoryService, reminders);
+        addressService, clientAddressService, childClientService, assignmentService,
+        Validation.buildDefaultValidatorFactory().getValidator(), referralDao, new MessageBuilder(),
+        allegationPerpetratorHistoryService, reminders);
   }
 
   /**

--- a/src/test/java/gov/ca/cwds/rest/business/rules/doctool/TestForLastUpdatedTimeIsUnique.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/doctool/TestForLastUpdatedTimeIsUnique.java
@@ -8,14 +8,13 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import gov.ca.cwds.data.cms.TestSystemCodeCache;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
 import javax.validation.Validation;
-
 import javax.validation.Validator;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,6 +40,7 @@ import gov.ca.cwds.data.cms.ReferralDao;
 import gov.ca.cwds.data.cms.ReporterDao;
 import gov.ca.cwds.data.cms.SsaName3Dao;
 import gov.ca.cwds.data.cms.StaffPersonDao;
+import gov.ca.cwds.data.cms.TestSystemCodeCache;
 import gov.ca.cwds.data.rules.TriggerTablesDao;
 import gov.ca.cwds.rest.api.Response;
 import gov.ca.cwds.rest.api.domain.ScreeningToReferral;
@@ -166,7 +166,11 @@ public class TestForLastUpdatedTimeIsUnique {
     drmsDocumentService = new DrmsDocumentService(drmsDocumentDao, staffPersonIdRetriever);
 
     assignmentDao = mock(AssignmentDao.class);
-    assignmentService = new AssignmentService(assignmentDao, staffPersonIdRetriever, validator);
+    staffpersonDao = mock(StaffPersonDao.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
+    triggerTablesDao = mock(TriggerTablesDao.class);
+    assignmentService = new AssignmentService(assignmentDao, nonLACountyTriggers, staffpersonDao,
+        triggerTablesDao, staffPersonIdRetriever, validator);
 
     clientDao = mock(ClientDao.class);
     staffpersonDao = mock(StaffPersonDao.class);
@@ -202,8 +206,9 @@ public class TestForLastUpdatedTimeIsUnique {
     laCountyTrigger = mock(LACountyTrigger.class);
     triggerTablesDao = mock(TriggerTablesDao.class);
     staffpersonDao = mock(StaffPersonDao.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
     clientAddressService = new ClientAddressService(clientAddressDao, staffpersonDao,
-        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever);
+        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever, nonLACountyTriggers);
 
     childClientDao = mock(ChildClientDao.class);
     childClientService = new ChildClientService(childClientDao, staffPersonIdRetriever);
@@ -211,8 +216,8 @@ public class TestForLastUpdatedTimeIsUnique {
     reminders = mock(Reminders.class);
 
     addressDao = mock(AddressDao.class);
-    addressService =
-        new AddressService(addressDao, staffPersonIdRetriever, ssaName3Dao, upperCaseTables, validator);
+    addressService = new AddressService(addressDao, staffPersonIdRetriever, ssaName3Dao,
+        upperCaseTables, validator);
 
 
     referralService = new ReferralService(referralDao, nonLACountyTriggers, laCountyTrigger,
@@ -221,9 +226,9 @@ public class TestForLastUpdatedTimeIsUnique {
 
     screeningToReferralService = new ScreeningToReferralService(referralService, clientService,
         allegationService, crossReportService, referralClientService, reporterService,
-        addressService, clientAddressService, childClientService,
-        assignmentService, Validation.buildDefaultValidatorFactory().getValidator(), referralDao,
-        new MessageBuilder(), allegationPerpetratorHistoryService, reminders);
+        addressService, clientAddressService, childClientService, assignmentService,
+        Validation.buildDefaultValidatorFactory().getValidator(), referralDao, new MessageBuilder(),
+        allegationPerpetratorHistoryService, reminders);
 
   }
 

--- a/src/test/java/gov/ca/cwds/rest/services/ScreeningToReferralServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/ScreeningToReferralServiceTest.java
@@ -24,8 +24,8 @@ import java.util.List;
 import java.util.Set;
 
 import javax.validation.Validation;
-
 import javax.validation.Validator;
+
 import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Assert;
 import org.junit.Before;
@@ -208,15 +208,17 @@ public class ScreeningToReferralServiceTest {
     reporterService = new ReporterService(reporterDao, staffPersonIdRetriever);
 
     addressDao = mock(AddressDao.class);
-    addressService =
-        new AddressService(addressDao, staffPersonIdRetriever, ssaName3Dao, upperCaseTables, validator);
+    addressService = new AddressService(addressDao, staffPersonIdRetriever, ssaName3Dao,
+        upperCaseTables, validator);
 
     clientAddressDao = mock(ClientAddressDao.class);
     laCountyTrigger = mock(LACountyTrigger.class);
     triggerTablesDao = mock(TriggerTablesDao.class);
     staffpersonDao = mock(StaffPersonDao.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
     clientAddressService = new ClientAddressService(clientAddressDao, staffpersonDao,
-        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever);
+        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever, nonLACountyTriggers);
+
 
     longTextDao = mock(LongTextDao.class);
     longTextService = new LongTextService(longTextDao, staffPersonIdRetriever);
@@ -228,7 +230,11 @@ public class ScreeningToReferralServiceTest {
     childClientService = new ChildClientService(childClientDao, staffPersonIdRetriever);
 
     assignmentDao = mock(AssignmentDao.class);
-    assignmentService = new AssignmentService(assignmentDao, staffPersonIdRetriever, validator);
+    staffpersonDao = mock(StaffPersonDao.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
+    triggerTablesDao = mock(TriggerTablesDao.class);
+    assignmentService = new AssignmentService(assignmentDao, nonLACountyTriggers, staffpersonDao,
+        triggerTablesDao, staffPersonIdRetriever, validator);
 
     reminders = mock(Reminders.class);
 
@@ -238,9 +244,9 @@ public class ScreeningToReferralServiceTest {
 
     screeningToReferralService = new ScreeningToReferralService(referralService, clientService,
         allegationService, crossReportService, referralClientService, reporterService,
-        addressService, clientAddressService, childClientService,
-        assignmentService, Validation.buildDefaultValidatorFactory().getValidator(), referralDao,
-        new MessageBuilder(), allegationPerpetratorHistoryService, reminders);
+        addressService, clientAddressService, childClientService, assignmentService,
+        Validation.buildDefaultValidatorFactory().getValidator(), referralDao, new MessageBuilder(),
+        allegationPerpetratorHistoryService, reminders);
   }
 
   @SuppressWarnings("javadoc")
@@ -404,8 +410,8 @@ public class ScreeningToReferralServiceTest {
     when(longTextDao.create(any(gov.ca.cwds.data.persistence.cms.LongText.class)))
         .thenReturn(longTextToCreate);
 
-    Referral referralCreated = referralService.createReferralWithDefaults(
-        screeningToReferral, "2016-08-03T01:00:00.000Z", "2016-08-03T01:00:00.000Z", null, new MessageBuilder());
+    Referral referralCreated = referralService.createReferralWithDefaults(screeningToReferral,
+        "2016-08-03T01:00:00.000Z", "2016-08-03T01:00:00.000Z", null, new MessageBuilder());
     assertThat(referralCreated.getApprovalStatusType(), is(equalTo((short) 118)));
   }
 
@@ -679,17 +685,16 @@ public class ScreeningToReferralServiceTest {
   @Test
   public void shouldFailWhenSpecifyingALegacyReferralIdThatDoesNotExist() throws Exception {
     MockedScreeningToReferralServiceBuilder builder = new MockedScreeningToReferralServiceBuilder();
-    screeningToReferralService = builder
-        .addReferralService(referralService)
-//        .addMessageBuilder(new MessageBuilder())
+    screeningToReferralService = builder.addReferralService(referralService)
+        // .addMessageBuilder(new MessageBuilder())
         .createScreeningToReferralService();
 
     ScreeningToReferral referral = new ScreeningToReferralResourceBuilder()
         .setReferralId("1234567ABC").createScreeningToReferral();
 
-    try{
+    try {
       Response response = screeningToReferralService.create(referral);
-    }catch(ServiceException e){
+    } catch (ServiceException e) {
       verify(builder.getMessageBuilder())
           .addError("Legacy Id does not correspond to an existing CMS/CWS Referral");
 
@@ -725,16 +730,15 @@ public class ScreeningToReferralServiceTest {
     when(drmsDocumentDao.create(any())).thenReturn(drmsDocument);
 
     referralService = mock(ReferralService.class);
-    when(referralService.createCmsReferralFromScreening(any(), any(), any(), any(), any())).thenReturn("REFERRALID");
+    when(referralService.createCmsReferralFromScreening(any(), any(), any(), any(), any()))
+        .thenReturn("REFERRALID");
     clientService = mock(ClientService.class);
     when(clientService.find(eq(victimClientLegacyId))).thenReturn(foundClient);
     when(clientService.create(any())).thenReturn(createdClient);
     when(clientService.update(eq(victimClientLegacyId), any())).thenReturn(updatedClient);
     screeningToReferralService = new MockedScreeningToReferralServiceBuilder()
-        .addClientService(clientService)
-        .addReferralService(referralService)
-        .addMessageBuilder(new MessageBuilder())
-        .createScreeningToReferralService();
+        .addClientService(clientService).addReferralService(referralService)
+        .addMessageBuilder(new MessageBuilder()).createScreeningToReferralService();
 
     screeningToReferralService.create(referral);
     verify(clientService).update(eq(victim.getLegacyId()), any());
@@ -796,9 +800,9 @@ public class ScreeningToReferralServiceTest {
     when(clientService.find(eq(victimClientLegacyId))).thenReturn(foundClient);
     when(clientService.create(any())).thenReturn(createdClient);
     when(clientService.update(eq(victimClientLegacyId), any())).thenReturn(updatedClient);
-    screeningToReferralService = new MockedScreeningToReferralServiceBuilder()
-        .addClientService(clientService)
-        .addMessageBuilder(new MessageBuilder()).createScreeningToReferralService();
+    screeningToReferralService =
+        new MockedScreeningToReferralServiceBuilder().addClientService(clientService)
+            .addMessageBuilder(new MessageBuilder()).createScreeningToReferralService();
 
     try {
       screeningToReferralService.create(referral);
@@ -944,11 +948,11 @@ public class ScreeningToReferralServiceTest {
         .setParticipants(participants).createScreeningToReferral();
 
     referralService = mock(ReferralService.class);
-    when(referralService.createCmsReferralFromScreening(any(), any(), any(), any(), any())).thenReturn("REFERRALID");
+    when(referralService.createCmsReferralFromScreening(any(), any(), any(), any(), any()))
+        .thenReturn("REFERRALID");
 
     screeningToReferralService =
-        new MockedScreeningToReferralServiceBuilder()
-            .addReferralService(referralService)
+        new MockedScreeningToReferralServiceBuilder().addReferralService(referralService)
             .addMessageBuilder(new MessageBuilder()).createScreeningToReferralService();
 
     Response response = screeningToReferralService.create(referral);
@@ -1086,8 +1090,7 @@ public class ScreeningToReferralServiceTest {
     DrmsDocumentService mockedDrmsDocService = mock(DrmsDocumentService.class);
     when(mockedDrmsDocService.create(any())).thenReturn(null);
     screeningToReferralService = new MockedScreeningToReferralServiceBuilder()
-        .addReferralService(referralService)
-        .createScreeningToReferralService();
+        .addReferralService(referralService).createScreeningToReferralService();
     Response response = screeningToReferralService.create(referral);
     assertFalse("Expected exception to have been thrown", true);
   }
@@ -1145,10 +1148,10 @@ public class ScreeningToReferralServiceTest {
     clientAddressService = mock(ClientAddressService.class);
     when(clientAddressService.find(any())).thenReturn(foundClientAddress);
 
-    screeningToReferralService = new MockedScreeningToReferralServiceBuilder()
-        .addAddressService(addressService).addClientAddressService(clientAddressService)
-        .addClientService(clientService)
-        .addMessageBuilder(new MessageBuilder()).createScreeningToReferralService();
+    screeningToReferralService =
+        new MockedScreeningToReferralServiceBuilder().addAddressService(addressService)
+            .addClientAddressService(clientAddressService).addClientService(clientService)
+            .addMessageBuilder(new MessageBuilder()).createScreeningToReferralService();
 
     Response response = screeningToReferralService.create(referral);
 
@@ -2670,11 +2673,11 @@ public class ScreeningToReferralServiceTest {
     when(drmsDocumentDao.create(any())).thenReturn(drmsDocument);
 
     referralService = mock(ReferralService.class);
-    when(referralService.createCmsReferralFromScreening(any(), any(), any(), any(), any())).thenReturn("REFERRALID");
+    when(referralService.createCmsReferralFromScreening(any(), any(), any(), any(), any()))
+        .thenReturn("REFERRALID");
 
     screeningToReferralService = new MockedScreeningToReferralServiceBuilder()
-        .addClientService(clientService)
-        .addReferralService(referralService)
+        .addClientService(clientService).addReferralService(referralService)
         .addMessageBuilder(new MessageBuilder()).createScreeningToReferralService();
 
     Response response = screeningToReferralService.create(referral);
@@ -3936,12 +3939,12 @@ public class ScreeningToReferralServiceTest {
     when(addressService.create(any())).thenReturn(postedAddress);
     when(addressService.createWithSingleTimestamp(any(), any())).thenReturn(postedAddress);
     referralService = mock(ReferralService.class);
-    when(referralService.createCmsReferralFromScreening(any(), any(), any(), any(), any())).thenReturn("REFERRALID");
+    when(referralService.createCmsReferralFromScreening(any(), any(), any(), any(), any()))
+        .thenReturn("REFERRALID");
 
     screeningToReferralService = new MockedScreeningToReferralServiceBuilder()
-        .addClientAddressService(clientAddressService)
-        .addClientService(clientService).addAddressService(addressService)
-        .addReferralService(referralService)
+        .addClientAddressService(clientAddressService).addClientService(clientService)
+        .addAddressService(addressService).addReferralService(referralService)
         .addMessageBuilder(new MessageBuilder()).createScreeningToReferralService();
 
     Response response = screeningToReferralService.create(referral);
@@ -4000,10 +4003,10 @@ public class ScreeningToReferralServiceTest {
     when(addressService.find(any())).thenReturn(existingAddress);
     when(addressService.create(any())).thenReturn(postedAddress);
 
-    screeningToReferralService = new MockedScreeningToReferralServiceBuilder()
-        .addClientAddressService(clientAddressService)
-        .addClientService(clientService).addAddressService(addressService)
-        .addMessageBuilder(new MessageBuilder()).createScreeningToReferralService();
+    screeningToReferralService =
+        new MockedScreeningToReferralServiceBuilder().addClientAddressService(clientAddressService)
+            .addClientService(clientService).addAddressService(addressService)
+            .addMessageBuilder(new MessageBuilder()).createScreeningToReferralService();
 
     try {
       Response response = screeningToReferralService.create(referral);
@@ -4069,10 +4072,10 @@ public class ScreeningToReferralServiceTest {
     when(addressService.create(any())).thenReturn(postedAddress);
 
     MessageBuilder messageBuilder = mock(MessageBuilder.class);
-    screeningToReferralService = new MockedScreeningToReferralServiceBuilder()
-        .addClientAddressService(clientAddressService)
-        .addClientService(clientService).addAddressService(addressService)
-        .addMessageBuilder(messageBuilder).createScreeningToReferralService();
+    screeningToReferralService =
+        new MockedScreeningToReferralServiceBuilder().addClientAddressService(clientAddressService)
+            .addClientService(clientService).addAddressService(addressService)
+            .addMessageBuilder(messageBuilder).createScreeningToReferralService();
 
     Response response = screeningToReferralService.create(referral);
     verify(messageBuilder, atLeastOnce()).addError("Unable to save Client");
@@ -4104,9 +4107,9 @@ public class ScreeningToReferralServiceTest {
     when(clientService.create(any())).thenReturn(postedClient);
     when(clientService.find(any())).thenReturn(null);
     when(drmsDocumentDao.create(any())).thenReturn(drmsDocument);
-    screeningToReferralService = new MockedScreeningToReferralServiceBuilder()
-        .addClientService(clientService)
-        .addMessageBuilder(new MessageBuilder()).createScreeningToReferralService();
+    screeningToReferralService =
+        new MockedScreeningToReferralServiceBuilder().addClientService(clientService)
+            .addMessageBuilder(new MessageBuilder()).createScreeningToReferralService();
 
     try {
       Response response = screeningToReferralService.create(referral);
@@ -4139,12 +4142,12 @@ public class ScreeningToReferralServiceTest {
     when(allegationService.find(allegation.getLegacyId())).thenReturn(mock(Allegation.class));
     MessageBuilder messageBuilder = new MessageBuilder();
     referralService = mock(ReferralService.class);
-    when(referralService.createCmsReferralFromScreening(any(), any(), any(), any(), any())).thenReturn("REFERRALID");
+    when(referralService.createCmsReferralFromScreening(any(), any(), any(), any(), any()))
+        .thenReturn("REFERRALID");
 
     screeningToReferralService = new MockedScreeningToReferralServiceBuilder()
         .addMessageBuilder(messageBuilder).addAllegationService(allegationService)
-        .addReferralService(referralService)
-        .createScreeningToReferralService();
+        .addReferralService(referralService).createScreeningToReferralService();
 
     Response response = screeningToReferralService.create(referral);
 
@@ -4572,11 +4575,11 @@ public class ScreeningToReferralServiceTest {
     MessageBuilder messageBuilder = new MessageBuilder();
 
     referralService = mock(ReferralService.class);
-    when(referralService.createCmsReferralFromScreening(any(), any(), any(), any(), any())).thenReturn("REFERRALID");
+    when(referralService.createCmsReferralFromScreening(any(), any(), any(), any(), any()))
+        .thenReturn("REFERRALID");
     screeningToReferralService =
         new MockedScreeningToReferralServiceBuilder().addMessageBuilder(messageBuilder)
-            .addAddressService(addressService)
-            .addReferralService(referralService)
+            .addAddressService(addressService).addReferralService(referralService)
             .addClientAddressService(clientAddressService).createScreeningToReferralService();
     Response response = screeningToReferralService.create(referral);
 
@@ -4760,12 +4763,12 @@ public class ScreeningToReferralServiceTest {
     when(addressService.createWithSingleTimestamp(any(), any())).thenReturn(postedAddress);
 
     referralService = mock(ReferralService.class);
-    when(referralService.createCmsReferralFromScreening(any(), any(), any(), any(), any())).thenReturn("REFERRALID");
+    when(referralService.createCmsReferralFromScreening(any(), any(), any(), any(), any()))
+        .thenReturn("REFERRALID");
 
     screeningToReferralService = new MockedScreeningToReferralServiceBuilder()
         .addAddressService(addressService).addClientAddressService(clientAddressService)
-        .addClientService(clientService)
-        .addReferralService(referralService)
+        .addClientService(clientService).addReferralService(referralService)
         .addMessageBuilder(new MessageBuilder()).createScreeningToReferralService();
 
     Response response = screeningToReferralService.create(referral);
@@ -5179,11 +5182,11 @@ public class ScreeningToReferralServiceTest {
     when(drmsDocumentDao.create(any())).thenReturn(drmsDocument);
 
     referralService = mock(ReferralService.class);
-    when(referralService.createCmsReferralFromScreening(any(), any(), any(), any(), any())).thenReturn("REFERRALID");
+    when(referralService.createCmsReferralFromScreening(any(), any(), any(), any(), any()))
+        .thenReturn("REFERRALID");
 
     screeningToReferralService = new MockedScreeningToReferralServiceBuilder()
-        .addClientService(clientService)
-        .addReferralService(referralService)
+        .addClientService(clientService).addReferralService(referralService)
         .addMessageBuilder(new MessageBuilder()).createScreeningToReferralService();
 
     Response response = screeningToReferralService.create(referral);

--- a/src/test/java/gov/ca/cwds/rest/services/cms/AssignmentServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/cms/AssignmentServiceTest.java
@@ -13,9 +13,9 @@ import static org.mockito.Mockito.when;
 
 import javax.persistence.EntityExistsException;
 import javax.persistence.EntityNotFoundException;
-
 import javax.validation.Validation;
 import javax.validation.Validator;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -25,10 +25,13 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import gov.ca.cwds.data.cms.AssignmentDao;
+import gov.ca.cwds.data.cms.StaffPersonDao;
+import gov.ca.cwds.data.rules.TriggerTablesDao;
 import gov.ca.cwds.fixture.AssignmentResourceBuilder;
 import gov.ca.cwds.rest.api.Response;
 import gov.ca.cwds.rest.api.domain.cms.Assignment;
 import gov.ca.cwds.rest.api.domain.cms.PostedAssignment;
+import gov.ca.cwds.rest.business.rules.NonLACountyTriggers;
 import gov.ca.cwds.rest.services.ServiceException;
 
 /**
@@ -39,7 +42,10 @@ import gov.ca.cwds.rest.services.ServiceException;
 public class AssignmentServiceTest {
 
   private AssignmentService assignmentService;
-  private AssignmentDao assignmentDao;;
+  private AssignmentDao assignmentDao;
+  private NonLACountyTriggers nonLACountyTriggers;
+  private StaffPersonDao staffpersonDao;
+  private TriggerTablesDao triggerTablesDao;
   private StaffPersonIdRetriever staffPersonIdRetriever;
   private Validator validator;
 
@@ -51,7 +57,11 @@ public class AssignmentServiceTest {
     validator = Validation.buildDefaultValidatorFactory().getValidator();
     assignmentDao = mock(AssignmentDao.class);
     staffPersonIdRetriever = mock(StaffPersonIdRetriever.class);
-    assignmentService = new AssignmentService(assignmentDao, staffPersonIdRetriever, validator);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
+    staffpersonDao = mock(StaffPersonDao.class);
+    triggerTablesDao = mock(TriggerTablesDao.class);
+    assignmentService = new AssignmentService(assignmentDao, nonLACountyTriggers, staffpersonDao,
+        triggerTablesDao, staffPersonIdRetriever, validator);
   }
 
   // find test

--- a/src/test/java/gov/ca/cwds/rest/services/cms/ClientAddressServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/cms/ClientAddressServiceTest.java
@@ -32,6 +32,7 @@ import gov.ca.cwds.rest.api.Response;
 import gov.ca.cwds.rest.api.domain.Address;
 import gov.ca.cwds.rest.api.domain.Participant;
 import gov.ca.cwds.rest.business.rules.LACountyTrigger;
+import gov.ca.cwds.rest.business.rules.NonLACountyTriggers;
 import gov.ca.cwds.rest.services.ServiceException;
 import gov.ca.cwds.rest.services.junit.template.ServiceTestTemplate;
 
@@ -46,6 +47,7 @@ public class ClientAddressServiceTest implements ServiceTestTemplate {
   StaffPersonDao staffpersonDao;
   TriggerTablesDao triggerTablesDao;
   LACountyTrigger laCountyTrigger;
+  NonLACountyTriggers nonLACountyTriggers;
   StaffPersonIdRetriever staffPersonIdRetriever;
 
   @SuppressWarnings("javadoc")
@@ -62,10 +64,11 @@ public class ClientAddressServiceTest implements ServiceTestTemplate {
     staffpersonDao = mock(StaffPersonDao.class);
     triggerTablesDao = mock(TriggerTablesDao.class);
     laCountyTrigger = mock(LACountyTrigger.class);
+    nonLACountyTriggers = mock(NonLACountyTriggers.class);
     staffPersonIdRetriever = mock(StaffPersonIdRetriever.class);
 
     clientAddressService = new ClientAddressService(clientAddressDao, staffpersonDao,
-        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever);
+        triggerTablesDao, laCountyTrigger, staffPersonIdRetriever, nonLACountyTriggers);
   }
 
   /**


### PR DESCRIPTION
Review the NonLACountyTriggers.Class, AssignmentService, ClientAddressService. When the user is from other than Non LA County we create the records and update the countyOwnership based on the countySpecificCode on the specific Entity.

Remaining are just changed the constructor.