### PR TITLE
https://osi-cwds.atlassian.net/browse/INT-973 HOI Cases and Referrals…

### DIFF
--- a/src/main/java/gov/ca/cwds/data/cms/CaseDao.java
+++ b/src/main/java/gov/ca/cwds/data/cms/CaseDao.java
@@ -1,5 +1,7 @@
 package gov.ca.cwds.data.cms;
 
+import java.util.Collection;
+
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
 import org.hibernate.type.StringType;
@@ -28,16 +30,16 @@ public class CaseDao extends CrudsDaoImpl<CmsCase> {
   }
 
   /**
-   * Find by client id
+   * Find by Victim Client Ids
    * 
-   * @param clientId - clientId
-   * @return the case
+   * @param clientIds - the victim client Ids
+   * @return all the cases for all the clients
    */
   @SuppressWarnings("unchecked")
-  public CmsCase[] findByClientId(String clientId) {
+  public CmsCase[] findByVictimClientIds(Collection<String> clientIds) {
     final Query<CmsCase> query = this.getSessionFactory().getCurrentSession()
-        .getNamedQuery("gov.ca.cwds.data.persistence.cms.CmsCase.findByClient");
-    query.setParameter("clientId", clientId, StringType.INSTANCE);
+        .getNamedQuery("gov.ca.cwds.data.persistence.cms.CmsCase.findByVictimClientIds");
+    query.setParameterList("clientIds", clientIds, StringType.INSTANCE);
     return query.list().toArray(new CmsCase[0]);
   }
 

--- a/src/main/java/gov/ca/cwds/data/cms/ReferralClientDao.java
+++ b/src/main/java/gov/ca/cwds/data/cms/ReferralClientDao.java
@@ -1,5 +1,7 @@
 package gov.ca.cwds.data.cms;
 
+import java.util.Collection;
+
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
 import org.hibernate.type.StringType;
@@ -42,16 +44,16 @@ public class ReferralClientDao extends CrudsDaoImpl<ReferralClient> {
   }
 
   /**
-   * Find by client id
+   * Find by client ids
    * 
-   * @param clientId - referralId
-   * @return the referalClient
+   * @param clientIds - clientlIds
+   * @return the referalClients
    */
   @SuppressWarnings("unchecked")
-  public ReferralClient[] findByClientId(String clientId) {
+  public ReferralClient[] findByClientIds(Collection<String> clientIds) {
     final Query<ReferralClient> query = this.getSessionFactory().getCurrentSession()
-        .getNamedQuery("gov.ca.cwds.data.persistence.cms.ReferralClient.findByClient");
-    query.setParameter("clientId", clientId, StringType.INSTANCE);
+        .getNamedQuery("gov.ca.cwds.data.persistence.cms.ReferralClient.findByClientIds");
+    query.setParameterList("clientIds", clientIds, StringType.INSTANCE);
     return query.list().toArray(new ReferralClient[0]);
   }
 

--- a/src/main/java/gov/ca/cwds/data/persistence/cms/CmsCase.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/cms/CmsCase.java
@@ -26,8 +26,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * 
  * @author CWDS API Team
  */
-@NamedQuery(name = "gov.ca.cwds.data.persistence.cms.CmsCase.findByClient",
-    query = "FROM CmsCase WHERE fkchldClt = :clientId")
+@NamedQuery(name = "gov.ca.cwds.data.persistence.cms.CmsCase.findByVictimClientIds",
+    query = "FROM CmsCase WHERE fkchldClt in :clientIds")
 @SuppressWarnings("javadoc")
 @Entity
 @Table(name = "CASE_T")

--- a/src/main/java/gov/ca/cwds/data/persistence/cms/ReferralClient.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/cms/ReferralClient.java
@@ -36,8 +36,8 @@ import gov.ca.cwds.rest.api.domain.DomainChef;
  */
 @NamedQuery(name = "gov.ca.cwds.data.persistence.cms.ReferralClient.findByReferral",
     query = "FROM ReferralClient WHERE referralId = :referralId")
-@NamedQuery(name = "gov.ca.cwds.data.persistence.cms.ReferralClient.findByClient",
-    query = "FROM ReferralClient WHERE clientId = :clientId")
+@NamedQuery(name = "gov.ca.cwds.data.persistence.cms.ReferralClient.findByClientIds",
+    query = "FROM ReferralClient WHERE clientId in :clientIds")
 @SuppressWarnings("serial")
 @Entity
 @Table(name = "REFR_CLT")

--- a/src/main/java/gov/ca/cwds/inject/ResourcesModule.java
+++ b/src/main/java/gov/ca/cwds/inject/ResourcesModule.java
@@ -36,8 +36,8 @@ import gov.ca.cwds.rest.api.domain.hoi.HOICase;
 import gov.ca.cwds.rest.api.domain.hoi.HOICaseResponse;
 import gov.ca.cwds.rest.api.domain.hoi.HOIReferral;
 import gov.ca.cwds.rest.api.domain.hoi.HOIReferralResponse;
+import gov.ca.cwds.rest.api.domain.hoi.HOIRequest;
 import gov.ca.cwds.rest.api.domain.hoi.HOIScreening;
-import gov.ca.cwds.rest.api.domain.hoi.HOIScreeningRequest;
 import gov.ca.cwds.rest.api.domain.hoi.HOIScreeningResponse;
 import gov.ca.cwds.rest.api.domain.hoi.InvolvementHistory;
 import gov.ca.cwds.rest.api.domain.investigation.Investigation;
@@ -517,21 +517,21 @@ public class ResourcesModule extends AbstractModule {
 
   @Provides
   @HOIReferralServiceBackedResource
-  public SimpleResourceDelegate<String, HOIReferral, HOIReferralResponse, HOIReferralService> referralHoiServiceBackedResource(
+  public SimpleResourceDelegate<HOIRequest, HOIReferral, HOIReferralResponse, HOIReferralService> referralHoiServiceBackedResource(
       Injector injector) {
     return new SimpleResourceDelegate<>(injector.getInstance(HOIReferralService.class));
   }
 
   @Provides
   @HOICaseServiceBackedResource
-  public SimpleResourceDelegate<String, HOICase, HOICaseResponse, HOICaseService> caseHoiServiceBackedResource(
+  public SimpleResourceDelegate<HOIRequest, HOICase, HOICaseResponse, HOICaseService> caseHoiServiceBackedResource(
       Injector injector) {
     return new SimpleResourceDelegate<>(injector.getInstance(HOICaseService.class));
   }
 
   @Provides
   @HOIScreeningServiceBackedResource
-  public SimpleResourceDelegate<HOIScreeningRequest, HOIScreening, HOIScreeningResponse, HOIScreeningService> screeningHOIServiceBackedResource(
+  public SimpleResourceDelegate<HOIRequest, HOIScreening, HOIScreeningResponse, HOIScreeningService> screeningHOIServiceBackedResource(
       Injector injector) {
     return new SimpleResourceDelegate<>(injector.getInstance(HOIScreeningService.class));
   }

--- a/src/main/java/gov/ca/cwds/rest/api/domain/hoi/HOIRequest.java
+++ b/src/main/java/gov/ca/cwds/rest/api/domain/hoi/HOIRequest.java
@@ -1,19 +1,27 @@
 package gov.ca.cwds.rest.api.domain.hoi;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import gov.ca.cwds.rest.api.Request;
-import io.dropwizard.jackson.JsonSnakeCase;
 import java.util.Set;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import gov.ca.cwds.rest.api.Request;
+import io.dropwizard.jackson.JsonSnakeCase;
+
 @JsonSnakeCase
-public class HOIScreeningRequest implements Request {
+public class HOIRequest implements Request {
+
+  /**
+   * default
+   */
+  private static final long serialVersionUID = 1L;
 
   @JsonProperty("client_ids")
   private Set<String> clientIds;
 
-  public HOIScreeningRequest() {
+  public HOIRequest() {
     // default
   }
 

--- a/src/main/java/gov/ca/cwds/rest/business/rules/CountyOfAssignedStaffWorker.java
+++ b/src/main/java/gov/ca/cwds/rest/business/rules/CountyOfAssignedStaffWorker.java
@@ -36,12 +36,10 @@ public class CountyOfAssignedStaffWorker implements RuleValidator {
   }
 
   private StaffPerson validatedStaffPerson(String staffPersonId) {
-    StaffPerson staffperson;
     if (staffPersonId == null) {
       throw new ServiceException("Assigned Staff Person Id is mandatory");
     } else {
-      staffperson = staffPersonDao.find(staffPersonId);
+      return staffPersonDao.find(staffPersonId);
     }
-    return staffperson;
   }
 }

--- a/src/main/java/gov/ca/cwds/rest/resources/hoi/HOICaseResource.java
+++ b/src/main/java/gov/ca/cwds/rest/resources/hoi/HOICaseResource.java
@@ -3,9 +3,8 @@ package gov.ca.cwds.rest.resources.hoi;
 import static gov.ca.cwds.rest.core.Api.RESOURCE_CASE_HISTORY_OF_INVOLVEMENT;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -15,6 +14,7 @@ import com.google.inject.Inject;
 import gov.ca.cwds.inject.HOICaseServiceBackedResource;
 import gov.ca.cwds.rest.api.domain.hoi.HOICase;
 import gov.ca.cwds.rest.api.domain.hoi.HOICaseResponse;
+import gov.ca.cwds.rest.api.domain.hoi.HOIRequest;
 import gov.ca.cwds.rest.resources.SimpleResourceDelegate;
 import gov.ca.cwds.rest.services.hoi.HOICaseService;
 import io.dropwizard.hibernate.UnitOfWork;
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiResponses;
 @Consumes(MediaType.APPLICATION_JSON)
 public class HOICaseResource {
 
-  private SimpleResourceDelegate<String, HOICase, HOICaseResponse, HOICaseService> simpleResourceDelegate;
+  private SimpleResourceDelegate<HOIRequest, HOICase, HOICaseResponse, HOICaseService> simpleResourceDelegate;
 
   /**
    * Constructor
@@ -50,29 +50,27 @@ public class HOICaseResource {
    */
   @Inject
   public HOICaseResource(
-      @HOICaseServiceBackedResource SimpleResourceDelegate<String, HOICase, HOICaseResponse, HOICaseService> simpleResourceDelegate) {
+      @HOICaseServiceBackedResource SimpleResourceDelegate<HOIRequest, HOICase, HOICaseResponse, HOICaseService> simpleResourceDelegate) {
     super();
     this.simpleResourceDelegate = simpleResourceDelegate;
   }
 
   /**
-   * Finds a cases HOI by client id.
+   * Finds a cases HOI by client ids.
    * 
-   * @param id the id
-   * 
+   * @param hoiCaseRequest HOI Case Request containing a list of Client Id-s
    * @return the response
    */
   @UnitOfWork(value = "cms")
-  @GET
-  @Path("/{id}")
+  @POST
   @ApiResponses(value = {@ApiResponse(code = 401, message = "Not Authorized"),
       @ApiResponse(code = 404, message = "Not found"),
       @ApiResponse(code = 406, message = "Accept Header not supported")})
   @ApiOperation(value = "Find cases history of involvement by clientId", response = HOICase[].class,
       code = 200)
-  public Response get(@PathParam("id") @ApiParam(required = true, name = "id",
-      value = "The id of the client") String id) {
-    return simpleResourceDelegate.find(id);
+  public Response post(@ApiParam(required = true, name = "clientIds",
+      value = "List of Client Id-s") HOIRequest hoiCaseRequest) {
+    return simpleResourceDelegate.find(hoiCaseRequest);
   }
 
 }

--- a/src/main/java/gov/ca/cwds/rest/resources/hoi/HOIReferralResource.java
+++ b/src/main/java/gov/ca/cwds/rest/resources/hoi/HOIReferralResource.java
@@ -3,9 +3,8 @@ package gov.ca.cwds.rest.resources.hoi;
 import static gov.ca.cwds.rest.core.Api.RESOURCE_REFERRAL_HISTORY_OF_INVOLVEMENT;
 
 import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -15,6 +14,7 @@ import com.google.inject.Inject;
 import gov.ca.cwds.inject.HOIReferralServiceBackedResource;
 import gov.ca.cwds.rest.api.domain.hoi.HOIReferral;
 import gov.ca.cwds.rest.api.domain.hoi.HOIReferralResponse;
+import gov.ca.cwds.rest.api.domain.hoi.HOIRequest;
 import gov.ca.cwds.rest.resources.SimpleResourceDelegate;
 import gov.ca.cwds.rest.services.hoi.HOIReferralService;
 import io.dropwizard.hibernate.UnitOfWork;
@@ -41,7 +41,7 @@ import io.swagger.annotations.ApiResponses;
 @Consumes(MediaType.APPLICATION_JSON)
 public class HOIReferralResource {
 
-  private SimpleResourceDelegate<String, HOIReferral, HOIReferralResponse, HOIReferralService> simpleResourceDelegate;
+  private SimpleResourceDelegate<HOIRequest, HOIReferral, HOIReferralResponse, HOIReferralService> simpleResourceDelegate;
 
   /**
    * Constructor
@@ -50,29 +50,27 @@ public class HOIReferralResource {
    */
   @Inject
   public HOIReferralResource(
-      @HOIReferralServiceBackedResource SimpleResourceDelegate<String, HOIReferral, HOIReferralResponse, HOIReferralService> simpleResourceDelegate) {
+      @HOIReferralServiceBackedResource SimpleResourceDelegate<HOIRequest, HOIReferral, HOIReferralResponse, HOIReferralService> simpleResourceDelegate) {
     super();
     this.simpleResourceDelegate = simpleResourceDelegate;
   }
 
   /**
-   * Finds an referrals HOI by client id.
+   * Finds an referrals HOI by client ids.
    * 
-   * @param id the id
-   * 
+   * @param hoiReferralRequest HOI Referral Request containing a list of Client Id-s
    * @return the response
    */
   @UnitOfWork(value = "cms")
-  @GET
-  @Path("/{id}")
+  @POST
   @ApiResponses(value = {@ApiResponse(code = 401, message = "Not Authorized"),
       @ApiResponse(code = 404, message = "Not found"),
       @ApiResponse(code = 406, message = "Accept Header not supported")})
   @ApiOperation(value = "Find referrals history of involvement by clientId",
       response = HOIReferral[].class, code = 200)
-  public Response get(@PathParam("id") @ApiParam(required = true, name = "id",
-      value = "The id of the client to find") String id) {
-    return simpleResourceDelegate.find(id);
+  public Response post(@ApiParam(required = true, name = "clientIds",
+      value = "List of Client Id-s") HOIRequest hoiReferralRequest) {
+    return simpleResourceDelegate.find(hoiReferralRequest);
   }
 
 }

--- a/src/main/java/gov/ca/cwds/rest/resources/hoi/HOIScreeningResource.java
+++ b/src/main/java/gov/ca/cwds/rest/resources/hoi/HOIScreeningResource.java
@@ -2,10 +2,6 @@ package gov.ca.cwds.rest.resources.hoi;
 
 import static gov.ca.cwds.rest.core.Api.RESOURCE_HOI_SCREENINGS;
 
-import gov.ca.cwds.rest.api.domain.hoi.HOIScreeningRequest;
-import gov.ca.cwds.rest.api.domain.hoi.HOIScreeningResponse;
-import gov.ca.cwds.rest.resources.SimpleResourceDelegate;
-import gov.ca.cwds.rest.services.hoi.HOIScreeningService;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -16,8 +12,12 @@ import javax.ws.rs.core.Response;
 import com.google.inject.Inject;
 
 import gov.ca.cwds.inject.HOIScreeningServiceBackedResource;
+import gov.ca.cwds.rest.api.domain.hoi.HOIRequest;
 import gov.ca.cwds.rest.api.domain.hoi.HOIScreening;
+import gov.ca.cwds.rest.api.domain.hoi.HOIScreeningResponse;
+import gov.ca.cwds.rest.resources.SimpleResourceDelegate;
 import gov.ca.cwds.rest.resources.TypedResourceDelegate;
+import gov.ca.cwds.rest.services.hoi.HOIScreeningService;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiResponses;
 @Consumes(MediaType.APPLICATION_JSON)
 public class HOIScreeningResource {
 
-  private SimpleResourceDelegate<HOIScreeningRequest, HOIScreening, HOIScreeningResponse, HOIScreeningService> simpleResourceDelegate;
+  private SimpleResourceDelegate<HOIRequest, HOIScreening, HOIScreeningResponse, HOIScreeningService> simpleResourceDelegate;
 
   /**
    * Constructor
@@ -51,7 +51,7 @@ public class HOIScreeningResource {
    */
   @Inject
   public HOIScreeningResource(
-      @HOIScreeningServiceBackedResource SimpleResourceDelegate<HOIScreeningRequest, HOIScreening, HOIScreeningResponse, HOIScreeningService> simpleResourceDelegate) {
+      @HOIScreeningServiceBackedResource SimpleResourceDelegate<HOIRequest, HOIScreening, HOIScreeningResponse, HOIScreeningService> simpleResourceDelegate) {
     this.simpleResourceDelegate = simpleResourceDelegate;
   }
 
@@ -69,7 +69,7 @@ public class HOIScreeningResource {
   @ApiOperation(value = "Find history of involvement by screening id",
       response = HOIScreeningResponse.class)
   public Response post(@ApiParam(required = true, name = "clientIds",
-      value = "List of Client Id-s") HOIScreeningRequest hoiScreeningRequest) {
+      value = "List of Client Id-s") HOIRequest hoiScreeningRequest) {
     return simpleResourceDelegate.find(hoiScreeningRequest);
   }
 

--- a/src/main/java/gov/ca/cwds/rest/services/hoi/HOICaseService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/hoi/HOICaseService.java
@@ -1,7 +1,9 @@
 package gov.ca.cwds.rest.services.hoi;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.joda.time.DateTime;
@@ -26,6 +28,7 @@ import gov.ca.cwds.rest.api.domain.cms.SystemCodeDescriptor;
 import gov.ca.cwds.rest.api.domain.hoi.HOICase;
 import gov.ca.cwds.rest.api.domain.hoi.HOICaseResponse;
 import gov.ca.cwds.rest.api.domain.hoi.HOIRelatedPerson;
+import gov.ca.cwds.rest.api.domain.hoi.HOIRequest;
 import gov.ca.cwds.rest.api.domain.hoi.HOISocialWorker;
 import gov.ca.cwds.rest.api.domain.hoi.HOIVictim;
 import gov.ca.cwds.rest.resources.SimpleResourceService;
@@ -38,7 +41,7 @@ import gov.ca.cwds.rest.resources.SimpleResourceService;
  * @author CWDS API Team
  *
  */
-public class HOICaseService extends SimpleResourceService<String, HOICase, HOICaseResponse> {
+public class HOICaseService extends SimpleResourceService<HOIRequest, HOICase, HOICaseResponse> {
 
   /**
    * Serial Version UID
@@ -67,28 +70,40 @@ public class HOICaseService extends SimpleResourceService<String, HOICase, HOICa
   }
 
   @Override
-  protected HOICaseResponse handleFind(String id) {
-    List<HOICase> cases = findByClientId(id);
-    return new HOICaseResponse(cases);
+  protected HOICaseResponse handleFind(HOIRequest hoiRequest) {
+    if (!hoiRequest.getClientIds().isEmpty()) {
+      List<HOICase> cases = findByClientId(hoiRequest);
+      return new HOICaseResponse(cases);
+    }
+    return emptyHoiCaseResponse();
   }
 
   /**
-   * @param id - id
-   * @return the cases linked to single client
+   * @param hoiRequest - hoiCaseRequest
+   * @return the cases linked to multiple client
    */
-  public List<HOICase> findByClientId(String id) {
-    List<String> clientIds = findAllRelatedClientIds(id);
+  public List<HOICase> findByClientId(HOIRequest hoiRequest) {
+    Set<String> clientIds = hoiRequest.getClientIds();
     return findAllCasesForAllClients(clientIds);
   }
 
-  private List<HOICase> findAllCasesForAllClients(List<String> clientIds) {
-    List<HOICase> hoicases = new ArrayList<>();
+  private HOICaseResponse emptyHoiCaseResponse() {
+    HOICaseResponse hoiCaseResponse = new HOICaseResponse();
+    hoiCaseResponse.setHoiCases(new ArrayList<>());
+    return hoiCaseResponse;
+  }
+
+  private List<HOICase> findAllCasesForAllClients(Set<String> clientIds) {
+    Set<String> allClientIds = new HashSet<>();
     for (String clientId : clientIds) {
-      CmsCase[] cmscases = caseDao.findByClientId(clientId);
-      for (CmsCase cmscase : cmscases) {
-        HOICase hoicase = constructHOICase(cmscase);
-        hoicases.add(hoicase);
-      }
+      allClientIds.addAll(findAllRelatedClientIds(clientId));
+    }
+    allClientIds.addAll(clientIds);
+    List<HOICase> hoicases = new ArrayList<>();
+    CmsCase[] cmscases = caseDao.findByVictimClientIds(allClientIds);
+    for (CmsCase cmscase : cmscases) {
+      HOICase hoicase = constructHOICase(cmscase);
+      hoicases.add(hoicase);
     }
     return hoicases;
   }

--- a/src/main/java/gov/ca/cwds/rest/services/hoi/HOIReferralService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/hoi/HOIReferralService.java
@@ -22,6 +22,7 @@ import gov.ca.cwds.data.persistence.cms.StaffPerson;
 import gov.ca.cwds.rest.api.domain.hoi.HOIReferral;
 import gov.ca.cwds.rest.api.domain.hoi.HOIReferralResponse;
 import gov.ca.cwds.rest.api.domain.hoi.HOIReporter.Role;
+import gov.ca.cwds.rest.api.domain.hoi.HOIRequest;
 import gov.ca.cwds.rest.resources.SimpleResourceService;
 
 /**
@@ -33,7 +34,7 @@ import gov.ca.cwds.rest.resources.SimpleResourceService;
  *
  */
 public class HOIReferralService
-    extends SimpleResourceService<String, HOIReferral, HOIReferralResponse> {
+    extends SimpleResourceService<HOIRequest, HOIReferral, HOIReferralResponse> {
 
   /**
    * 
@@ -55,20 +56,16 @@ public class HOIReferralService
   }
 
   @Override
-  public HOIReferralResponse handleFind(String clientId) {
+  protected HOIReferralResponse handleFind(HOIRequest hoiRequest) {
     HOIReferralResponse hoiReferralResponse = new HOIReferralResponse();
-
-    Client client = clientDao.find(clientId);
-    if (client != null) {
-      List<ReferralClient> referralClientList = fetchReferralClient(clientId);
-
-      for (ReferralClient referralClient : referralClientList) {
-        fetchEachReferral(hoiReferralResponse, referralClient);
-      }
-
-      return hoiReferralResponse;
+    List<ReferralClient> referralClientList = fetchReferralClient(hoiRequest.getClientIds());
+    if (referralClientList.isEmpty()) {
+      return emptyHoiReferralResponse();
     }
-    return emptyHoiReferralResponse();
+    for (ReferralClient referralClient : referralClientList) {
+      fetchEachReferral(hoiReferralResponse, referralClient);
+    }
+    return hoiReferralResponse;
   }
 
   private HOIReferralResponse emptyHoiReferralResponse() {
@@ -91,8 +88,8 @@ public class HOIReferralService
         staffPerson, reporter, allegationMap, role));
   }
 
-  private List<ReferralClient> fetchReferralClient(String clientId) {
-    ReferralClient[] referralClients = referralClientDao.findByClientId(clientId);
+  private List<ReferralClient> fetchReferralClient(Set<String> clientIds) {
+    ReferralClient[] referralClients = referralClientDao.findByClientIds(clientIds);
     return Arrays.asList(referralClients);
   }
 

--- a/src/main/java/gov/ca/cwds/rest/services/hoi/HOIScreeningService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/hoi/HOIScreeningService.java
@@ -1,24 +1,26 @@
 package gov.ca.cwds.rest.services.hoi;
 
-import gov.ca.cwds.data.ns.ScreeningDao;
-import gov.ca.cwds.data.persistence.ns.ScreeningEntity;
-import gov.ca.cwds.rest.api.domain.hoi.HOIScreening;
-import gov.ca.cwds.rest.api.domain.hoi.HOIScreeningRequest;
-import gov.ca.cwds.rest.api.domain.hoi.HOIScreeningResponse;
-import gov.ca.cwds.rest.resources.SimpleResourceService;
 import java.util.HashSet;
 import java.util.Set;
+
 import org.apache.commons.lang3.NotImplementedException;
 
 import com.google.inject.Inject;
+
+import gov.ca.cwds.data.ns.ScreeningDao;
+import gov.ca.cwds.data.persistence.ns.ScreeningEntity;
+import gov.ca.cwds.rest.api.domain.hoi.HOIRequest;
+import gov.ca.cwds.rest.api.domain.hoi.HOIScreening;
+import gov.ca.cwds.rest.api.domain.hoi.HOIScreeningResponse;
+import gov.ca.cwds.rest.resources.SimpleResourceService;
 
 /**
  * Business layer object to work on Screening History Of Involvement
  *
  * @author CWDS API Team
  */
-public class HOIScreeningService extends
-    SimpleResourceService<HOIScreeningRequest, HOIScreening, HOIScreeningResponse> {
+public class HOIScreeningService
+    extends SimpleResourceService<HOIRequest, HOIScreening, HOIScreeningResponse> {
 
   @Inject
   ScreeningDao screeningDao;
@@ -35,7 +37,7 @@ public class HOIScreeningService extends
    * @return list of HOI Screenings
    */
   @Override
-  protected HOIScreeningResponse handleFind(HOIScreeningRequest hoiScreeningRequest) {
+  protected HOIScreeningResponse handleFind(HOIRequest hoiScreeningRequest) {
     Set<HOIScreening> screenings = new HashSet<>();
     for (ScreeningEntity screeningEntity : screeningDao
         .findScreeningsByClientIds(hoiScreeningRequest.getClientIds())) {

--- a/src/test/java/gov/ca/cwds/data/cms/CaseDaoIT.java
+++ b/src/test/java/gov/ca/cwds/data/cms/CaseDaoIT.java
@@ -6,6 +6,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+import java.util.Arrays;
+
 import javax.persistence.EntityExistsException;
 import javax.persistence.EntityNotFoundException;
 
@@ -126,7 +128,7 @@ public class CaseDaoIT {
    */
   @Test
   public void testFindClientId() throws Exception {
-    CmsCase[] CmsCases = caseDao.findByClientId(clientId);
+    CmsCase[] CmsCases = caseDao.findByVictimClientIds(Arrays.asList(clientId));
     assertThat(CmsCases, notNullValue());
     assertThat(CmsCases.length, greaterThanOrEqualTo(1));
   }

--- a/src/test/java/gov/ca/cwds/data/cms/ReferralClientDaoIT.java
+++ b/src/test/java/gov/ca/cwds/data/cms/ReferralClientDaoIT.java
@@ -7,6 +7,8 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 
+import java.util.Arrays;
+
 import javax.persistence.EntityExistsException;
 import javax.persistence.EntityNotFoundException;
 
@@ -152,7 +154,8 @@ public class ReferralClientDaoIT implements DaoTestTemplate {
    */
   @Test
   public void testFindClientId() throws Exception {
-    ReferralClient[] referralClients = referralClientDao.findByClientId("AapJGAU04Z");
+    ReferralClient[] referralClients =
+        referralClientDao.findByClientIds(Arrays.asList("AapJGAU04Z"));
     assertThat(referralClients, notNullValue());
     assertThat(referralClients.length, greaterThanOrEqualTo(1));
   }

--- a/src/test/java/gov/ca/cwds/rest/resources/hoi/HOICaseResourceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/resources/hoi/HOICaseResourceTest.java
@@ -17,6 +17,7 @@ import com.squarespace.jersey2.guice.JerseyGuiceUtils;
 
 import gov.ca.cwds.rest.api.domain.hoi.HOICase;
 import gov.ca.cwds.rest.api.domain.hoi.HOICaseResponse;
+import gov.ca.cwds.rest.api.domain.hoi.HOIRequest;
 import gov.ca.cwds.rest.resources.SimpleResourceDelegate;
 import gov.ca.cwds.rest.resources.cms.JerseyGuiceRule;
 import gov.ca.cwds.rest.services.hoi.HOICaseService;
@@ -42,7 +43,7 @@ public class HOICaseResourceTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
-  private static SimpleResourceDelegate<String, HOICase, HOICaseResponse, HOICaseService> simpleResourceDelegate =
+  private static SimpleResourceDelegate<HOIRequest, HOICase, HOICaseResponse, HOICaseService> simpleResourceDelegate =
       mock(SimpleResourceDelegate.class);
 
   @ClassRule

--- a/src/test/java/gov/ca/cwds/rest/resources/hoi/HOIReferralResourceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/resources/hoi/HOIReferralResourceTest.java
@@ -17,6 +17,7 @@ import com.squarespace.jersey2.guice.JerseyGuiceUtils;
 
 import gov.ca.cwds.rest.api.domain.hoi.HOIReferral;
 import gov.ca.cwds.rest.api.domain.hoi.HOIReferralResponse;
+import gov.ca.cwds.rest.api.domain.hoi.HOIRequest;
 import gov.ca.cwds.rest.core.Api;
 import gov.ca.cwds.rest.resources.SimpleResourceDelegate;
 import gov.ca.cwds.rest.resources.cms.JerseyGuiceRule;
@@ -45,7 +46,7 @@ public class HOIReferralResourceTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
-  private static SimpleResourceDelegate<String, HOIReferral, HOIReferralResponse, HOIReferralService> simpleResourceDelegate =
+  private static SimpleResourceDelegate<HOIRequest, HOIReferral, HOIReferralResponse, HOIReferralService> simpleResourceDelegate =
       mock(SimpleResourceDelegate.class);
 
   @ClassRule

--- a/src/test/java/gov/ca/cwds/rest/resources/hoi/HOIScreeningResourceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/resources/hoi/HOIScreeningResourceTest.java
@@ -5,13 +5,9 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import gov.ca.cwds.rest.api.domain.hoi.HOIScreening;
-import gov.ca.cwds.rest.api.domain.hoi.HOIScreeningRequest;
-import gov.ca.cwds.rest.api.domain.hoi.HOIScreeningResponse;
-import gov.ca.cwds.rest.resources.SimpleResourceDelegate;
-import gov.ca.cwds.rest.services.hoi.HOIScreeningService;
 import java.util.HashSet;
 import java.util.Set;
+
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 
@@ -25,8 +21,13 @@ import org.mockito.MockitoAnnotations;
 
 import com.squarespace.jersey2.guice.JerseyGuiceUtils;
 
+import gov.ca.cwds.rest.api.domain.hoi.HOIRequest;
+import gov.ca.cwds.rest.api.domain.hoi.HOIScreening;
+import gov.ca.cwds.rest.api.domain.hoi.HOIScreeningResponse;
 import gov.ca.cwds.rest.resources.ServiceBackedResourceDelegate;
+import gov.ca.cwds.rest.resources.SimpleResourceDelegate;
 import gov.ca.cwds.rest.resources.cms.JerseyGuiceRule;
+import gov.ca.cwds.rest.services.hoi.HOIScreeningService;
 import io.dropwizard.testing.junit.ResourceTestRule;
 
 /****
@@ -51,8 +52,8 @@ public class HOIScreeningResourceTest {
   public ExpectedException thrown = ExpectedException.none();
 
   @SuppressWarnings("unchecked")
-  private final static SimpleResourceDelegate<HOIScreeningRequest, HOIScreening, HOIScreeningResponse, HOIScreeningService> simpleResourceDelegate = mock(
-      SimpleResourceDelegate.class);
+  private final static SimpleResourceDelegate<HOIRequest, HOIScreening, HOIScreeningResponse, HOIScreeningService> simpleResourceDelegate =
+      mock(SimpleResourceDelegate.class);
 
   @ClassRule
   public final static ResourceTestRule inMemoryResource = ResourceTestRule.builder()
@@ -67,7 +68,7 @@ public class HOIScreeningResourceTest {
   public void findDelegatesToResourceDelegate() {
     Set<String> clientIds = new HashSet<>();
     clientIds.add("1");
-    HOIScreeningRequest hoiScreeningRequest = new HOIScreeningRequest();
+    HOIRequest hoiScreeningRequest = new HOIRequest();
     hoiScreeningRequest.setClientIds(clientIds);
     Entity requestEntity = Entity.entity(hoiScreeningRequest, MediaType.APPLICATION_JSON_TYPE);
 

--- a/src/test/java/gov/ca/cwds/rest/services/hoi/HOICaseServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/hoi/HOICaseServiceTest.java
@@ -6,6 +6,10 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Before;
 import org.junit.Rule;
@@ -26,6 +30,7 @@ import gov.ca.cwds.fixture.StaffPersonEntityBuilder;
 import gov.ca.cwds.rest.api.domain.cms.SystemCodeCache;
 import gov.ca.cwds.rest.api.domain.hoi.HOICase;
 import gov.ca.cwds.rest.api.domain.hoi.HOICaseResponse;
+import gov.ca.cwds.rest.api.domain.hoi.HOIRequest;
 
 /**
  * @author CWDS API Team
@@ -38,6 +43,7 @@ public class HOICaseServiceTest {
   private ClientDao clientDao;
   private ClientRelationshipDao clientRelationshipDao;
   private HOICaseService target;
+  private HOIRequest request;
 
   /**
    * Initialize system code cache
@@ -59,6 +65,8 @@ public class HOICaseServiceTest {
     clientDao = mock(ClientDao.class);
     clientRelationshipDao = mock(ClientRelationshipDao.class);
     target = new HOICaseService(caseDao, clientDao, clientRelationshipDao);
+    request = new HOIRequest();
+    request.setClientIds(Stream.of("123").collect(Collectors.toSet()));
   }
 
   @Test
@@ -72,9 +80,9 @@ public class HOICaseServiceTest {
     when(clientRelationshipDao.findBySecondaryClientId(any(String.class)))
         .thenReturn(relationships);
     Client client = new ClientEntityBuilder().build();
-    when(caseDao.findByClientId(any(String.class))).thenReturn(cases);
+    when(caseDao.findByVictimClientIds(any(Collection.class))).thenReturn(cases);
     when(clientDao.find(any(String.class))).thenReturn(client);
-    HOICaseResponse response = target.handleFind("1234");
+    HOICaseResponse response = target.handleFind(request);
     assertThat(response, notNullValue());
   }
 
@@ -90,9 +98,9 @@ public class HOICaseServiceTest {
     when(clientRelationshipDao.findBySecondaryClientId(any(String.class)))
         .thenReturn(relationships);
     Client client = new ClientEntityBuilder().build();
-    when(caseDao.findByClientId(any(String.class))).thenReturn(cases);
+    when(caseDao.findByVictimClientIds(any(Collection.class))).thenReturn(cases);
     when(clientDao.find(any(String.class))).thenReturn(client);
-    HOICaseResponse response = target.handleFind("1234");
+    HOICaseResponse response = target.handleFind(request);
     assertThat(response, notNullValue());
   }
 

--- a/src/test/java/gov/ca/cwds/rest/services/hoi/HOIReferralServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/hoi/HOIReferralServiceTest.java
@@ -8,8 +8,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Before;
@@ -19,7 +21,6 @@ import org.junit.rules.ExpectedException;
 
 import gov.ca.cwds.data.cms.ClientDao;
 import gov.ca.cwds.data.cms.ReferralClientDao;
-import gov.ca.cwds.data.cms.TestSystemCodeCache;
 import gov.ca.cwds.data.persistence.cms.Allegation;
 import gov.ca.cwds.data.persistence.cms.Client;
 import gov.ca.cwds.data.persistence.cms.Referral;
@@ -35,6 +36,7 @@ import gov.ca.cwds.rest.api.domain.cms.Reporter;
 import gov.ca.cwds.rest.api.domain.cms.SystemCodeCache;
 import gov.ca.cwds.rest.api.domain.hoi.HOIReferral;
 import gov.ca.cwds.rest.api.domain.hoi.HOIReferralResponse;
+import gov.ca.cwds.rest.api.domain.hoi.HOIRequest;
 
 /**
  * @author CWDS API Team
@@ -45,11 +47,7 @@ public class HOIReferralServiceTest {
   private ClientDao clientDao;
   private ReferralClientDao referralClientDao;
   private HOIReferralService hoiService;
-
-  /**
-   * Initialize system code cache
-   */
-  private TestSystemCodeCache testSystemCodeCache = new TestSystemCodeCache();
+  private HOIRequest request;
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -65,6 +63,8 @@ public class HOIReferralServiceTest {
     clientDao = mock(ClientDao.class);
     referralClientDao = mock(ReferralClientDao.class);
     hoiService = new HOIReferralService(clientDao, referralClientDao);
+    request = new HOIRequest();
+    request.setClientIds(Stream.of("123").collect(Collectors.toSet()));
   }
 
   /**
@@ -111,9 +111,9 @@ public class HOIReferralServiceTest {
     gov.ca.cwds.data.persistence.cms.ReferralClient[] referralClients = {persistent1, persistent2};
 
     when(clientDao.find(any(String.class))).thenReturn(client);
-    when(referralClientDao.findByClientId(any(String.class))).thenReturn(referralClients);
+    when(referralClientDao.findByClientIds(any(Collection.class))).thenReturn(referralClients);
 
-    HOIReferralResponse response = hoiService.handleFind("123");
+    HOIReferralResponse response = hoiService.handleFind(request);
     assertThat(response.getHoiReferrals().size(), is(equalTo(2)));
   }
 
@@ -159,9 +159,9 @@ public class HOIReferralServiceTest {
     gov.ca.cwds.data.persistence.cms.ReferralClient[] referralClients = {persistent1, persistent2};
 
     when(clientDao.find(any(String.class))).thenReturn(client);
-    when(referralClientDao.findByClientId(any(String.class))).thenReturn(referralClients);
+    when(referralClientDao.findByClientIds(any(Collection.class))).thenReturn(referralClients);
 
-    HOIReferralResponse response = hoiService.handleFind("123");
+    HOIReferralResponse response = hoiService.handleFind(request);
     assertThat(response.getHoiReferrals().size(), is(equalTo(2)));
   }
 
@@ -204,9 +204,9 @@ public class HOIReferralServiceTest {
     gov.ca.cwds.data.persistence.cms.ReferralClient[] referralClients = {persistent1, persistent2};
 
     when(clientDao.find(any(String.class))).thenReturn(client);
-    when(referralClientDao.findByClientId(any(String.class))).thenReturn(referralClients);
+    when(referralClientDao.findByClientIds(any(Collection.class))).thenReturn(referralClients);
 
-    HOIReferralResponse response = hoiService.handleFind("123");
+    HOIReferralResponse response = hoiService.handleFind(request);
     assertThat(response.getHoiReferrals().size(), is(equalTo(2)));
   }
 
@@ -249,9 +249,9 @@ public class HOIReferralServiceTest {
     gov.ca.cwds.data.persistence.cms.ReferralClient[] referralClients = {persistent1, persistent2};
 
     when(clientDao.find(any(String.class))).thenReturn(client);
-    when(referralClientDao.findByClientId(any(String.class))).thenReturn(referralClients);
+    when(referralClientDao.findByClientIds(any(Collection.class))).thenReturn(referralClients);
 
-    HOIReferralResponse response = hoiService.handleFind("123");
+    HOIReferralResponse response = hoiService.handleFind(request);
     assertThat(response.getHoiReferrals().size(), is(equalTo(2)));
   }
 
@@ -297,9 +297,9 @@ public class HOIReferralServiceTest {
     gov.ca.cwds.data.persistence.cms.ReferralClient[] referralClients = {persistent1, persistent2};
 
     when(clientDao.find(any(String.class))).thenReturn(client);
-    when(referralClientDao.findByClientId(any(String.class))).thenReturn(referralClients);
+    when(referralClientDao.findByClientIds(any(Collection.class))).thenReturn(referralClients);
 
-    HOIReferralResponse response = hoiService.handleFind("123");
+    HOIReferralResponse response = hoiService.handleFind(request);
     assertThat(response.getHoiReferrals().size(), is(equalTo(2)));
   }
 

--- a/src/test/java/gov/ca/cwds/rest/services/hoi/HOIScreeningServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/hoi/HOIScreeningServiceTest.java
@@ -6,22 +6,25 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import gov.ca.cwds.data.ns.ParticipantDao;
 import gov.ca.cwds.data.ns.ScreeningDao;
 import gov.ca.cwds.data.persistence.ns.IntakeLOVCodeEntity;
 import gov.ca.cwds.data.persistence.ns.ScreeningEntity;
 import gov.ca.cwds.fixture.hoi.HOIScreeningBuilder;
 import gov.ca.cwds.rest.api.domain.DomainChef;
+import gov.ca.cwds.rest.api.domain.hoi.HOIRequest;
 import gov.ca.cwds.rest.api.domain.hoi.HOIScreening;
-import gov.ca.cwds.rest.api.domain.hoi.HOIScreeningRequest;
 import gov.ca.cwds.rest.api.domain.hoi.HOIScreeningResponse;
-import java.util.HashSet;
-import java.util.Set;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 import gov.ca.cwds.rest.filters.TestingRequestExecutionContext;
 
 /***
@@ -29,7 +32,6 @@ import gov.ca.cwds.rest.filters.TestingRequestExecutionContext;
  * @author CWDS API Team
  *
  */
-@SuppressWarnings("javadoc")
 public class HOIScreeningServiceTest {
 
   private HOIScreeningService hoiScreeningService;
@@ -48,8 +50,7 @@ public class HOIScreeningServiceTest {
     ScreeningDao screeningDao = mock(ScreeningDao.class);
     Set<String> clientIds = new HashSet<>();
     clientIds.add("1");
-    when(screeningDao.findScreeningsByClientIds(clientIds))
-        .thenReturn(mockScreeningEntityList());
+    when(screeningDao.findScreeningsByClientIds(clientIds)).thenReturn(mockScreeningEntityList());
     IntakeLOVCodeEntity mockIntakeLOVCodeEntity = new IntakeLOVCodeEntity();
     mockIntakeLOVCodeEntity.setLgSysId(1101L);
     mockIntakeLOVCodeEntity.setIntakeDisplay("Sacramento");
@@ -69,12 +70,9 @@ public class HOIScreeningServiceTest {
   public void findReturnsExpectedHistoryOfInvolvement() {
     HOIScreeningResponse expectedResponse = createExpectedResponse();
 
-    Set<String> clientIds = new HashSet<>();
-    clientIds.add("1");
-    HOIScreeningRequest hoiScreeningRequest = new HOIScreeningRequest();
-    hoiScreeningRequest.setClientIds(clientIds);
+    HOIRequest hoiScreeningRequest = new HOIRequest();
+    hoiScreeningRequest.setClientIds(Stream.of("1").collect(Collectors.toSet()));
     HOIScreeningResponse actualResponse = hoiScreeningService.handleFind(hoiScreeningRequest);
-    
     assertThat(actualResponse, is(expectedResponse));
   }
 
@@ -85,11 +83,10 @@ public class HOIScreeningServiceTest {
   }
 
   private Set<ScreeningEntity> mockScreeningEntityList() {
-    ScreeningEntity entity = new ScreeningEntity("224", null,
-        DomainChef.uncookDateString("2017-11-30"),
-        DomainChef.uncookDateString("2017-12-10"), "sacramento", null,
-        null, null, null, null, "promote to referral",
-        "drug counseling", null, null, null);
+    ScreeningEntity entity =
+        new ScreeningEntity("224", null, DomainChef.uncookDateString("2017-11-30"),
+            DomainChef.uncookDateString("2017-12-10"), "sacramento", null, null, null, null, null,
+            "promote to referral", "drug counseling", null, null, null);
 
     Set<ScreeningEntity> result = new HashSet<>();
     result.add(entity);

--- a/src/test/java/gov/ca/cwds/rest/services/hoi/InvolvementHistoryServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/hoi/InvolvementHistoryServiceTest.java
@@ -8,12 +8,11 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import gov.ca.cwds.data.ns.ParticipantDao;
-import gov.ca.cwds.rest.api.domain.hoi.HOIScreeningRequest;
-import gov.ca.cwds.rest.api.domain.hoi.HOIScreeningResponse;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Before;
@@ -23,6 +22,7 @@ import org.junit.rules.ExpectedException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import gov.ca.cwds.data.ns.ParticipantDao;
 import gov.ca.cwds.fixture.hoi.HOICaseResourceBuilder;
 import gov.ca.cwds.fixture.hoi.HOIReferralResourceBuilder;
 import gov.ca.cwds.rest.api.Response;
@@ -30,6 +30,8 @@ import gov.ca.cwds.rest.api.domain.hoi.HOICase;
 import gov.ca.cwds.rest.api.domain.hoi.HOICaseResponse;
 import gov.ca.cwds.rest.api.domain.hoi.HOIReferral;
 import gov.ca.cwds.rest.api.domain.hoi.HOIReferralResponse;
+import gov.ca.cwds.rest.api.domain.hoi.HOIRequest;
+import gov.ca.cwds.rest.api.domain.hoi.HOIScreeningResponse;
 import gov.ca.cwds.rest.api.domain.hoi.InvolvementHistory;
 import gov.ca.cwds.rest.filters.TestingRequestExecutionContext;
 import io.dropwizard.jackson.Jackson;
@@ -39,7 +41,6 @@ import io.dropwizard.jackson.Jackson;
  * @author CWDS API Team
  *
  */
-@SuppressWarnings("javadoc")
 public class InvolvementHistoryServiceTest {
 
   private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
@@ -48,6 +49,7 @@ public class InvolvementHistoryServiceTest {
   private HOIReferralService hoiReferralService;
   private HOIScreeningService hoiScreeningService;
   private InvolvementHistoryService involvementHistoryService;
+  private HOIRequest hoiRequest;
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -55,14 +57,15 @@ public class InvolvementHistoryServiceTest {
   @Before
   public void setup() throws Exception {
     new TestingRequestExecutionContext("0X5");
-
+    hoiRequest = new HOIRequest();
+    hoiRequest.setClientIds(Stream.of("123").collect(Collectors.toSet()));
     hoiCaseService = mock(HOICaseService.class);
     HOICase hoicase = new HOICaseResourceBuilder().createHOICase();
     List<HOICase> hoicases = new ArrayList<>();
     hoicases.add(hoicase);
     HOICaseResponse hoiCaseResponse = new HOICaseResponse();
     hoiCaseResponse.setHoiCases(hoicases);
-    when(hoiCaseService.find(any(String.class))).thenReturn(hoiCaseResponse);
+    when(hoiCaseService.find(any(HOIRequest.class))).thenReturn(hoiCaseResponse);
 
     hoiReferralService = mock(HOIReferralService.class);
     HOIReferral hoireferral = new HOIReferralResourceBuilder().createHOIReferral();
@@ -70,12 +73,11 @@ public class InvolvementHistoryServiceTest {
     hoireferrals.add(hoireferral);
     HOIReferralResponse hoiReferralResponse = new HOIReferralResponse();
     hoiReferralResponse.setHoiReferrals(hoireferrals);
-    when(hoiReferralService.handleFind(any(String.class))).thenReturn(hoiReferralResponse);
+    when(hoiReferralService.handleFind(any(HOIRequest.class))).thenReturn(hoiReferralResponse);
 
     hoiScreeningService = mock(HOIScreeningService.class);
     HOIScreeningResponse hoiScreeningResponse = new HOIScreeningResponse(new HashSet<>());
-    when(hoiScreeningService.handleFind(any(HOIScreeningRequest.class)))
-        .thenReturn(hoiScreeningResponse);
+    when(hoiScreeningService.handleFind(any(HOIRequest.class))).thenReturn(hoiScreeningResponse);
 
     involvementHistoryService = new InvolvementHistoryService();
     involvementHistoryService.hoiCaseService = hoiCaseService;


### PR DESCRIPTION
… Endpoint Refactor: Consistent with Screenings Endpoint

Refactored HOI Cases and HOI Referrals endpoints to consume a list of client Ids instead of a single client Id. The behavior of screenings/{id}/history_of_involvement endpoint remains the same.

## Description
HOI Cases and HOI Referrals endpoints consumed a single Client Id where as HOI Screenings consumed a list of Client Ids as this was more efficient. Refactored HOI Cases and HOI Referrals endpoints to consume a list of client Ids instead of a single client Id. The behavior of screenings/{id}/history_of_involvement endpoint remains the same.

## Jira Issue link
https://osi-cwds.atlassian.net/browse/INT-973 

## Tests
- I have included unit tests 

## Types of changes
- [x ] New feature (non-breaking change which adds functionality)
- [x ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x ] My code follows the google code style of this project.
- [ x] I have ran all tests for the project.
- [ x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
