### PR TITLE
INT-1447

### DIFF
--- a/src/main/java/gov/ca/cwds/rest/services/hoi/HOIReferralService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/hoi/HOIReferralService.java
@@ -2,8 +2,8 @@ package gov.ca.cwds.rest.services.hoi;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -71,11 +71,17 @@ public class HOIReferralService
     if (referralClientList.isEmpty()) {
       return emptyHoiReferralResponse();
     }
-    List<HOIReferral> hoiReferrals = new ArrayList<>(referralClientList.size());
-    for (ReferralClient referralClient : referralClientList) {
+    // eliminate duplicate ReferralClient records
+    ArrayList<ReferralClient> referralClientArrayList = new ArrayList<ReferralClient>(referralClientList);
+    Set<ReferralClient> referralClientSet = new LinkedHashSet<ReferralClient>(referralClientList);
+    referralClientArrayList.clear();
+    referralClientArrayList.addAll(referralClientSet);
+    
+    List<HOIReferral> hoiReferrals = new ArrayList<>(referralClientArrayList.size());
+    for (ReferralClient referralClient : referralClientArrayList) {
       hoiReferrals.add(createHOIReferral(referralClient));
     }
-    Collections.sort(hoiReferrals);
+ 
     hoiReferralResponse.setHoiReferrals(hoiReferrals);
     return hoiReferralResponse;
   }

--- a/src/test/java/gov/ca/cwds/rest/api/domain/hoi/HOIReferralResponseTest.java
+++ b/src/test/java/gov/ca/cwds/rest/api/domain/hoi/HOIReferralResponseTest.java
@@ -10,6 +10,8 @@ import java.util.List;
 
 import org.junit.Test;
 
+import gov.ca.cwds.fixture.hoi.HOIReferralResourceBuilder;
+
 /**
  * @author CWDS API Team
  *
@@ -39,12 +41,67 @@ public class HOIReferralResponseTest {
    */
   @Test
   public void getHoiReferrals_Args__() throws Exception {
-    HOIReferralResponse target = new HOIReferralResponse();
+    
+	HOIReferralResponse target = new HOIReferralResponse();
+    
     List<HOIReferral> actual = target.getHoiReferrals();
     List<HOIReferral> expected = new ArrayList<>();
     assertThat(actual, is(equalTo(expected)));
   }
 
+  @Test
+  public void shouldSetHoiReferrals() throws Exception {
+	List<HOIReferral> hoiReferrals = new ArrayList<>();
+	HOIReferral hoiReferral = new HOIReferralResourceBuilder().createHOIReferral();
+	hoiReferrals.add(hoiReferral);
+	HOIReferralResponse target = new HOIReferralResponse();
+	target.setHoiReferrals(hoiReferrals);
+	List<HOIReferral> actual = target.getHoiReferrals();
+	assertThat(actual, is(equalTo(hoiReferrals)));	
+  }
+  
+  @Test
+  public void shouldAddHoiReferral() throws Exception {
+	List<HOIReferral> referrals = new ArrayList<>();
+	List<HOIReferral> hoiReferrals = new ArrayList<>();
+	HOIReferral hoiReferral = new HOIReferralResourceBuilder().createHOIReferral();	
+	
+	referrals.add(hoiReferral);
+	hoiReferrals.addAll(referrals);
+
+	HOIReferralResponse target = new HOIReferralResponse();
+	target.setHoiReferrals(referrals);
+
+	HOIReferral newHOIReferral = new HOIReferralResourceBuilder().createHOIReferral();
+	
+	target.addHoiReferral(newHOIReferral);
+	hoiReferrals.add(newHOIReferral);
+	List<HOIReferral> actual = target.getHoiReferrals();
+	
+	assertThat(actual.size(), is(equalTo(hoiReferrals.size())));
+  }
+  
+  @Test
+  public void shouldNotAddNullHoiReferral() throws Exception {
+	List<HOIReferral> referrals = new ArrayList<>();
+	List<HOIReferral> hoiReferrals = new ArrayList<>();
+	HOIReferral hoiReferral = new HOIReferralResourceBuilder().createHOIReferral();	
+	referrals.add(hoiReferral);
+
+	HOIReferralResponse target = new HOIReferralResponse();
+	target.setHoiReferrals(referrals);
+
+	hoiReferrals.addAll(referrals);
+	
+	HOIReferral nullHOIReferral = null;
+	
+	target.addHoiReferral(nullHOIReferral);
+	List<HOIReferral> actual = target.getHoiReferrals();
+	
+	assertThat(actual.size(), is(equalTo(hoiReferrals.size())));
+	
+  }
+  
   /**
    * @throws Exception - Exception
    */

--- a/src/test/java/gov/ca/cwds/rest/services/hoi/HOIReferralServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/hoi/HOIReferralServiceTest.java
@@ -133,6 +133,104 @@ public class HOIReferralServiceTest {
     assertThat(response.getHoiReferrals().size(), is(equalTo(2)));
   }
 
+  @Test
+  public void shouldEliminateDuplicateHOIReferrals() throws Exception {
+	
+	Date referralDate = new Date();
+	Date clientDate = new Date();
+	Date allegationDate = new Date();
+	String clientId1 = "1234567ABC";
+	String clientId2 = "2345678ABC";
+	
+	// set up the allegations
+    Allegation allegation1 = new AllegationEntityBuilder()
+    		.setReferralId("ABC1234567")
+        .setVictimClientId(clientId1)
+        .setPerpetratorClientId(clientId2)
+        .setAbuseEndDate(allegationDate)
+        .setAbuseStartDate(allegationDate)
+        .build();
+    Allegation allegation2 = new AllegationEntityBuilder()
+    		.setReferralId("ABC1234568")
+        .setVictimClientId(clientId1)
+        .setPerpetratorClientId(clientId2)
+        .setAbuseEndDate(allegationDate)
+        .setAbuseStartDate(allegationDate)
+        .build();
+
+    StaffPerson staffPerson = new StaffPersonEntityBuilder().setId("0X5").build();
+    Reporter reporter = new CmsReporterResourceBuilder().build();
+    gov.ca.cwds.data.persistence.cms.Reporter persistentReporter =
+        new gov.ca.cwds.data.persistence.cms.Reporter(reporter, "0X5", new Date());
+
+    Referral referral1 = new ReferralEntityBuilder()
+    		.setId("ABC1234567")
+    		.setReceivedDate(referralDate)
+        .setAllegations(Arrays.asList(allegation1).stream().collect(Collectors.toSet()))
+        .setReporter(persistentReporter)
+        .setFirstResponseDeterminedByStaffPersonId("0X5")
+        .build();
+    Referral referral2 = new ReferralEntityBuilder()
+    		.setId("ABC1234568")
+    		.setReceivedDate(referralDate)
+        .setAllegations(Arrays.asList(allegation2).stream().collect(Collectors.toSet()))
+        .setReporter(persistentReporter)
+        .setFirstResponseDeterminedByStaffPersonId("0X5")
+        .build();
+
+    referral1.setStaffPerson(staffPerson);
+    referral2.setStaffPerson(staffPerson);
+
+    Client client1 = new ClientEntityBuilder().setId("1234567ABC").build();
+    
+    ReferralClient referralCliemtDomain11  = new ReferralClientResourceBuilder()
+    		.setClientId(clientId1)
+    		.setReferralId("ABC1234567")
+    		.buildReferralClient();
+    gov.ca.cwds.data.persistence.cms.ReferralClient referralClient1 =
+        new gov.ca.cwds.data.persistence.cms.ReferralClient(referralCliemtDomain11, "OXA",
+        	clientDate);
+    referralClient1.setReferral(referral1);
+
+    ReferralClient referralCliemtDomain12 = new ReferralClientResourceBuilder()
+		.setClientId(clientId2)
+		.setReferralId("ABC1234568")
+		.buildReferralClient();
+    gov.ca.cwds.data.persistence.cms.ReferralClient referralClient2 =
+        new gov.ca.cwds.data.persistence.cms.ReferralClient(referralCliemtDomain12, "OXA",
+        	clientDate);
+    referralClient2.setReferral(referral2);
+    
+    ReferralClient referralCliemtDomain21 = new ReferralClientResourceBuilder()
+		.setClientId(clientId1)
+		.setReferralId("ABC1234567")
+		.buildReferralClient();
+    gov.ca.cwds.data.persistence.cms.ReferralClient referralClient3 =
+        new gov.ca.cwds.data.persistence.cms.ReferralClient(referralCliemtDomain21, "OXA",
+        	clientDate);
+    referralClient3.setReferral(referral1);
+    
+    ReferralClient referralCliemtDomain22 = new ReferralClientResourceBuilder()
+		.setClientId(clientId2)
+		.setReferralId("ABC1234568")
+		.buildReferralClient();
+    gov.ca.cwds.data.persistence.cms.ReferralClient referralClient4 =
+        new gov.ca.cwds.data.persistence.cms.ReferralClient(referralCliemtDomain22, "OXA",
+        	clientDate);
+    referralClient4.setReferral(referral2);
+
+    gov.ca.cwds.data.persistence.cms.ReferralClient[] referralClients = {referralClient1, 
+    		referralClient2,
+    		referralClient3,
+    		referralClient4};
+
+    when(clientDao.find(any(String.class))).thenReturn(client1);
+    when(referralClientDao.findByClientIds(any(Collection.class))).thenReturn(referralClients);
+
+    HOIReferralResponse response = hoiService.handleFind(request);
+    assertThat(response.getHoiReferrals().size(), is(equalTo(2)));	
+  }
+  
   /**
    * @throws Exception - Exception
    */


### PR DESCRIPTION
HOIReferralService now processes unique Referral Id's of the returned REFERRAL_CLIENT rows of the specified Client(s).
## Description
Duplicate referrals were sometime show in the history of involvement for multiple clients due the clients being victims or perpetrator's on the same referral.

Duplicates occur if:

Client A is victim in Referral X
Client B is perpetrator in Referral X
Client A is victim in Referral Y
Client B is perpetrator in Referral Y

In this case the following ReferralClient(REFRL_CLT) rows exist:

|| Referral Id || Client Id || Third Id ||
| X | A | 1 |
| X | B | 2 |
| Y | A | 3 |
| Y | B | 4 |

If one were to query the table to select rows with Client Id = 'A' or Client Id = 'B' the results would be the four rows as shown above.  This is essentially what happens in HOI Referrals when the payload is sent with the client ID's for which to show Referral history.

Modification were made to eliminate the duplicate rows (by referral Id) so that only unique Referral information is shown in the history of involvement.

## Jira Issue link
https://osi-cwds.atlassian.net/browse/INT-1447

## Tests
- [X] I have included unit tests 
- [ ] I have included functional tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the google code style of this project.
- [X] I have ran all tests for the project.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [X] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
