### PR TITLE
INT-1447 eliminate duplicate referral ID's

### DIFF
--- a/src/main/java/gov/ca/cwds/rest/api/domain/cms/CmsDocReferralClient.java
+++ b/src/main/java/gov/ca/cwds/rest/api/domain/cms/CmsDocReferralClient.java
@@ -264,14 +264,8 @@ public class CmsDocReferralClient extends ReportingDomain
      * @see java.lang.Object#hashCode()
      */
     @Override
-    public final int hashCode() {
-      final int PRIME = 43;
-      int result = 1;
-
-      result = (PRIME * result) + ((name == null) ? PRIME : name.hashCode());
-      result = (PRIME * result) + ((content == null) ? PRIME : content.hashCode());
-
-      return result;
+    public int hashCode() {
+      return HashCodeBuilder.reflectionHashCode(this, false);
     }
 
     /**

--- a/src/main/java/gov/ca/cwds/rest/api/domain/cms/PostedCmsReferral.java
+++ b/src/main/java/gov/ca/cwds/rest/api/domain/cms/PostedCmsReferral.java
@@ -38,11 +38,10 @@ public class PostedCmsReferral extends ReportingDomain {
     super();
     this.referral = referral;
     this.client = new LinkedHashSet<>();
-    for (PostedClient resultClient : client)
-      this.client.add(resultClient);
+    this.client.addAll(client);
     this.allegation = new LinkedHashSet<>();
-    for (PostedAllegation resultAllegation : allegation)
-      this.allegation.add(resultAllegation);
+    this.allegation.addAll(allegation);
+    
     this.crossReport = crossReport;
     this.referralClient = referralClient;
     this.reporter = reporter;

--- a/src/main/java/gov/ca/cwds/rest/services/hoi/HOIReferralService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/hoi/HOIReferralService.java
@@ -3,7 +3,6 @@ package gov.ca.cwds.rest.services.hoi;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -71,12 +70,18 @@ public class HOIReferralService
     if (referralClientList.isEmpty()) {
       return emptyHoiReferralResponse();
     }
-    // eliminate duplicate ReferralClient records
+    // eliminate  rows  with duplicate referral Id's from referralClientArrayList
     ArrayList<ReferralClient> referralClientArrayList = new ArrayList<>(referralClientList);
-    Set<ReferralClient> referralClientSet = new LinkedHashSet<>(referralClientList);
+    HashMap<String, ReferralClient> uniqueReferralIds = new HashMap<String, ReferralClient>();
+    for (ReferralClient referralClient : referralClientArrayList) {
+      uniqueReferralIds.put(referralClient.getReferralId(), referralClient);
+    }
     referralClientArrayList.clear();
-    referralClientArrayList.addAll(referralClientSet);
     
+    for (Map.Entry<String, ReferralClient> uniqueReferral:uniqueReferralIds.entrySet()) {
+      referralClientArrayList.add(uniqueReferral.getValue());
+    }
+        
     List<HOIReferral> hoiReferrals = new ArrayList<>(referralClientArrayList.size());
     for (ReferralClient referralClient : referralClientArrayList) {
       hoiReferrals.add(createHOIReferral(referralClient));


### PR DESCRIPTION
Eliminate duplicate Referrals from returning from HOIReferralService

## Description
HOIReferralService queries the ReferralClient table by Client Id which can lead to ReferralClient rows with duplicate Referral Id's.  This modification eliminates multiple Referral Id's so that the service returns unique Referrals corresponding to the Client Id's passed to it.

## Jira Issue link
INT-1447 - Duplicate results on history of involvement cases and referrals

## Tests
- [X] I have included unit tests 
- [ ] I have included functional tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [X] My code follows the google code style of this project.
- [X] I have ran all tests for the project.
- [X] My code is in a stable state ready to be deployable, but not necessarily complete.
- [X] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
