### PR TITLE
Added a check for Empty describableIds

### DIFF
--- a/src/main/java/gov/ca/cwds/data/ns/LegacyDescriptorDao.java
+++ b/src/main/java/gov/ca/cwds/data/ns/LegacyDescriptorDao.java
@@ -3,16 +3,20 @@ package gov.ca.cwds.data.ns;
 import static gov.ca.cwds.data.persistence.ns.LegacyDescriptorEntity.DESCRIBABLE_TYPE_ADDRESS;
 import static gov.ca.cwds.data.persistence.ns.LegacyDescriptorEntity.DESCRIBABLE_TYPE_PARTICIPANT;
 
-import com.google.inject.Inject;
-import gov.ca.cwds.data.CrudsDaoImpl;
-import gov.ca.cwds.data.persistence.ns.LegacyDescriptorEntity;
-import gov.ca.cwds.inject.NsSessionFactory;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
+
+import com.google.inject.Inject;
+
+import gov.ca.cwds.data.CrudsDaoImpl;
+import gov.ca.cwds.data.persistence.ns.LegacyDescriptorEntity;
+import gov.ca.cwds.inject.NsSessionFactory;
 
 /**
  * Address DAO
@@ -78,15 +82,18 @@ public class LegacyDescriptorDao extends CrudsDaoImpl<LegacyDescriptorEntity> {
 
   private Map<String, LegacyDescriptorEntity> findLegacyDescriptors(Set<String> describableIds,
       String describableType) {
-    Set<Long> longDescribableIds = describableIds.stream().map(Long::valueOf)
-        .collect(Collectors.toSet());
+    Set<Long> longDescribableIds =
+        describableIds.stream().map(Long::valueOf).collect(Collectors.toSet());
     @SuppressWarnings("unchecked")
     final Query<LegacyDescriptorEntity> query = this.getSessionFactory().getCurrentSession()
         .getNamedQuery(LegacyDescriptorEntity.FIND_BY_DESCRIBABLE_IDS_AND_TYPE)
         .setParameter("describableIds", longDescribableIds)
         .setParameter("describableType", describableType);
-
-    return query.list().stream()
-        .collect(Collectors.toMap(d -> String.valueOf(d.getDescribableId().longValue()), d -> d));
+    if (!describableIds.isEmpty()) {
+      return query.list().stream()
+          .collect(Collectors.toMap(d -> String.valueOf(d.getDescribableId().longValue()), d -> d));
+    } else {
+      return new HashMap<>();
+    }
   }
 }


### PR DESCRIPTION
## Description
If the describable Ids are coming as an empty set, List is throwing an exception, So fixed the issue by adding a null check before it iterates the list.

## Jira Issue link
https://osi-cwds.atlassian.net/browse/INT-1667

## Tests
- [ ] I have included unit tests 
- [ ] I have included functional tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the google code style of this project.
- [x] I have ran all tests for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
