### PR TITLE
AS-9: NullPointerException on Screening HOI

### DIFF
--- a/src/main/java/gov/ca/cwds/data/cms/ClientRelationshipDao.java
+++ b/src/main/java/gov/ca/cwds/data/cms/ClientRelationshipDao.java
@@ -71,13 +71,13 @@ public class ClientRelationshipDao extends BaseDaoImpl<ClientRelationship> {
    */
   public Map<String, Collection<ClientRelationship>> findByPrimaryClientIds(
       Collection<String> clientIds) {
+    if (clientIds == null || clientIds.isEmpty()) {
+      return new HashMap<>();
+    }
     @SuppressWarnings("unchecked") final Query<ClientRelationship> query = this.getSessionFactory()
         .getCurrentSession()
         .getNamedQuery(FIND_CLIENT_RELATIONSHIPS_BY_PRIMARY_CLIENT_IDS);
     query.setParameter("clientIds", clientIds);
-    if (clientIds == null || clientIds.isEmpty()) {
-      return new HashMap<>();
-    }
     Map<String, Collection<ClientRelationship>> relationships = new HashMap<>(clientIds.size());
     for (ClientRelationship rel : query.list()) {
       if (!relationships.containsKey(rel.getPrimaryClientId())) {
@@ -94,13 +94,13 @@ public class ClientRelationshipDao extends BaseDaoImpl<ClientRelationship> {
    */
   public Map<String, Collection<ClientRelationship>> findBySecondaryClientIds(
       Collection<String> clientIds) {
+    if (clientIds == null || clientIds.isEmpty()) {
+      return new HashMap<>();
+    }
     @SuppressWarnings("unchecked") final Query<ClientRelationship> query = this.getSessionFactory()
         .getCurrentSession()
         .getNamedQuery(FIND_CLIENT_RELATIONSHIPS_BY_SECONDARY_CLIENT_IDS);
     query.setParameter("clientIds", clientIds);
-    if (clientIds == null || clientIds.isEmpty()) {
-      return new HashMap<>();
-    }
     Map<String, Collection<ClientRelationship>> relationships = new HashMap<>(clientIds.size());
     for (ClientRelationship rel : query.list()) {
       if (!relationships.containsKey(rel.getSecondaryClientId())) {

--- a/src/main/java/gov/ca/cwds/data/cms/ReferralClientDao.java
+++ b/src/main/java/gov/ca/cwds/data/cms/ReferralClientDao.java
@@ -35,8 +35,8 @@ public class ReferralClientDao extends CrudsDaoImpl<ReferralClient> {
    * @param referralId - referralId
    * @return the referralClient,
    */
-  @SuppressWarnings("unchecked")
   public ReferralClient[] findByReferralId(String referralId) {
+    @SuppressWarnings("unchecked")
     final Query<ReferralClient> query = this.getSessionFactory().getCurrentSession()
         .getNamedQuery("gov.ca.cwds.data.persistence.cms.ReferralClient.findByReferral");
     query.setParameter("referralId", referralId, StringType.INSTANCE);
@@ -49,8 +49,8 @@ public class ReferralClientDao extends CrudsDaoImpl<ReferralClient> {
    * @param clientIds - clientlIds
    * @return the referalClients
    */
-  @SuppressWarnings("unchecked")
   public ReferralClient[] findByClientIds(Collection<String> clientIds) {
+    @SuppressWarnings("unchecked")
     final Query<ReferralClient> query = this.getSessionFactory().getCurrentSession()
         .getNamedQuery("gov.ca.cwds.data.persistence.cms.ReferralClient.findByClientIds");
     query.setParameterList("clientIds", clientIds, StringType.INSTANCE);

--- a/src/main/java/gov/ca/cwds/data/cms/ReporterDao.java
+++ b/src/main/java/gov/ca/cwds/data/cms/ReporterDao.java
@@ -31,14 +31,11 @@ public class ReporterDao extends BaseDaoImpl<Reporter> {
    * @return - list of Reporters
    */
   public Reporter[] findInvestigationReportersByReferralId(String referralId) {
-
+    @SuppressWarnings("unchecked")
     Query<Reporter> query = this.getSessionFactory().getCurrentSession()
         .getNamedQuery(
             "gov.ca.cwds.data.persistence.cms.Reporter.findInvestigationReportersByReferralId")
         .setParameter("referralId", referralId);
     return query.list().toArray(new Reporter[0]);
-
   }
-
-
 }

--- a/src/main/java/gov/ca/cwds/data/cms/StaffPersonDao.java
+++ b/src/main/java/gov/ca/cwds/data/cms/StaffPersonDao.java
@@ -37,12 +37,12 @@ public class StaffPersonDao extends BaseDaoImpl<StaffPerson> {
    * @return map where key is a StaffPerson id and value is a StaffPerson itself
    */
   public Map<String, StaffPerson> findByIds(Collection<String> ids) {
-    @SuppressWarnings("unchecked")
-    final Query<StaffPerson> query = this.getSessionFactory().getCurrentSession()
-        .getNamedQuery(constructNamedQueryName("findByIds")).setParameter("ids", ids);
     if (ids == null || ids.isEmpty()) {
       return new HashMap<>();
     }
+    @SuppressWarnings("unchecked")
+    final Query<StaffPerson> query = this.getSessionFactory().getCurrentSession()
+        .getNamedQuery(constructNamedQueryName("findByIds")).setParameter("ids", ids);
     return query.list().stream().collect(Collectors.toMap(StaffPerson::getId, s -> s));
   }
 

--- a/src/main/java/gov/ca/cwds/data/ns/IntakeLOVCodeDao.java
+++ b/src/main/java/gov/ca/cwds/data/ns/IntakeLOVCodeDao.java
@@ -16,7 +16,6 @@ import gov.ca.cwds.inject.NsSessionFactory;
 
 /**
  * @author CWDS API team
- *
  */
 public class IntakeLOVCodeDao extends BaseDaoImpl<IntakeLOVCodeEntity> {
 
@@ -37,15 +36,14 @@ public class IntakeLOVCodeDao extends BaseDaoImpl<IntakeLOVCodeEntity> {
    * @return map where key is an intake code and value is an IntakeLOVCodeEntity
    */
   public Map<String, IntakeLOVCodeEntity> findIntakeLOVCodesByIntakeCodes(Set<String> intakeCodes) {
-    @SuppressWarnings("unchecked")
-    final Query<IntakeLOVCodeEntity> query = this.getSessionFactory().getCurrentSession()
-        .getNamedQuery(constructNamedQueryName("findIntakeLOVCodesByIntakeCodes"))
-        .setParameter("intakeCodes", intakeCodes);
-    if (intakeCodes != null && !intakeCodes.isEmpty()) {
-      return query.list().stream()
-          .collect(Collectors.toMap(IntakeLOVCodeEntity::getIntakeCode, c -> c));
-    } else {
+    if (intakeCodes == null || intakeCodes.isEmpty()) {
       return new HashMap<>();
     }
+    @SuppressWarnings("unchecked") final Query<IntakeLOVCodeEntity> query = this.getSessionFactory()
+        .getCurrentSession()
+        .getNamedQuery(constructNamedQueryName("findIntakeLOVCodesByIntakeCodes"))
+        .setParameter("intakeCodes", intakeCodes);
+    return query.list().stream()
+        .collect(Collectors.toMap(IntakeLOVCodeEntity::getIntakeCode, c -> c));
   }
 }

--- a/src/main/java/gov/ca/cwds/data/ns/LegacyDescriptorDao.java
+++ b/src/main/java/gov/ca/cwds/data/ns/LegacyDescriptorDao.java
@@ -82,6 +82,9 @@ public class LegacyDescriptorDao extends CrudsDaoImpl<LegacyDescriptorEntity> {
 
   private Map<String, LegacyDescriptorEntity> findLegacyDescriptors(Set<String> describableIds,
       String describableType) {
+    if (describableIds == null || describableIds.isEmpty()) {
+      return new HashMap<>();
+    }
     Set<Long> longDescribableIds =
         describableIds.stream().map(Long::valueOf).collect(Collectors.toSet());
     @SuppressWarnings("unchecked")
@@ -89,11 +92,7 @@ public class LegacyDescriptorDao extends CrudsDaoImpl<LegacyDescriptorEntity> {
         .getNamedQuery(LegacyDescriptorEntity.FIND_BY_DESCRIBABLE_IDS_AND_TYPE)
         .setParameter("describableIds", longDescribableIds)
         .setParameter("describableType", describableType);
-    if (!describableIds.isEmpty()) {
-      return query.list().stream()
-          .collect(Collectors.toMap(d -> String.valueOf(d.getDescribableId().longValue()), d -> d));
-    } else {
-      return new HashMap<>();
-    }
+    return query.list().stream()
+        .collect(Collectors.toMap(d -> String.valueOf(d.getDescribableId().longValue()), d -> d));
   }
 }

--- a/src/main/java/gov/ca/cwds/data/ns/ParticipantDao.java
+++ b/src/main/java/gov/ca/cwds/data/ns/ParticipantDao.java
@@ -54,15 +54,13 @@ public class ParticipantDao extends BaseDaoImpl<ParticipantEntity> {
    * screening
    */
   public Map<String, Set<ParticipantEntity>> findByScreeningIds(Set<String> screeningIds) {
+    if (screeningIds == null || screeningIds.isEmpty()) {
+      return new HashMap<>();
+    }
     @SuppressWarnings("unchecked") final Query<ParticipantEntity> query = this.getSessionFactory()
         .getCurrentSession()
         .getNamedQuery(FIND_PARTICIPANTS_BY_SCREENING_IDS)
         .setParameter("screeningIds", screeningIds);
-
-    if (screeningIds == null || screeningIds.isEmpty()) {
-      return new HashMap<>();
-    }
-
     Map<String, Set<ParticipantEntity>> result = new HashMap<>(screeningIds.size());
     for (ParticipantEntity participantEntity : query.list()) {
       String screeningId = participantEntity.getScreeningId();

--- a/src/main/java/gov/ca/cwds/rest/resources/hoi/HoiCaseResource.java
+++ b/src/main/java/gov/ca/cwds/rest/resources/hoi/HoiCaseResource.java
@@ -61,7 +61,7 @@ public class HoiCaseResource {
    * @param clientIds - clientIds
    * @return the hoi cases
    */
-  @UnitOfWork(value = "cms")
+  @UnitOfWork(value = "cms", readOnly = true, transactional = false)
   @GET
   @ApiResponses(value = {@ApiResponse(code = 401, message = "Not Authorized"),
       @ApiResponse(code = 404, message = "Not found"),

--- a/src/main/java/gov/ca/cwds/rest/resources/hoi/HoiReferralResource.java
+++ b/src/main/java/gov/ca/cwds/rest/resources/hoi/HoiReferralResource.java
@@ -61,7 +61,7 @@ public class HoiReferralResource {
    * @param clientIds - clientIds
    * @return the hoi referrals
    */
-  @UnitOfWork(value = "cms")
+  @UnitOfWork(value = "cms", readOnly = true, transactional = false)
   @GET
   @ApiResponses(value = {@ApiResponse(code = 401, message = "Not Authorized"),
       @ApiResponse(code = 404, message = "Not found"),

--- a/src/main/java/gov/ca/cwds/rest/services/hoi/HOIScreeningService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/hoi/HOIScreeningService.java
@@ -7,6 +7,7 @@ import gov.ca.cwds.data.ns.ParticipantDao;
 import gov.ca.cwds.data.persistence.ns.ParticipantEntity;
 import io.dropwizard.hibernate.UnitOfWork;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -54,11 +55,22 @@ public class HOIScreeningService
   @Inject
   AuthorizationService authorizationService;
 
+  private Comparator<HOIScreening> screeningsComparator;
+
   /**
    * Construct the object
    */
-  public HOIScreeningService() {
+  HOIScreeningService() {
     super();
+    screeningsComparator = (s1, s2) -> {
+      if (s2.getStartDate() == null) {
+        return 1;
+      } else if (s1.getStartDate() == null) {
+        return -1;
+      } else {
+        return s2.getStartDate().compareTo(s1.getStartDate());
+      }
+    };
   }
 
   /**
@@ -128,8 +140,7 @@ public class HOIScreeningService
   }
 
   Set<HOIScreening> buildHoiScreenings(HOIScreeningData hsd) {
-    Set<HOIScreening> screenings =
-        new TreeSet<>((s1, s2) -> s2.getStartDate().compareTo(s1.getStartDate()));
+    Set<HOIScreening> screenings = new TreeSet<>(screeningsComparator);
     for (ScreeningEntity screeningEntity : hsd.getScreeningEntities()) {
       /*
        * NOTE: When we want to enable authorizations for screening history, we can add following


### PR DESCRIPTION
It is possible to create a Screening without Start Date.
When such Screening appears in HOI, attempt to sort Screenings by Start Date fails with NullPointerException.
Screenings without Start Date should appear on top without any secondary criteria.

## Jira Issue link
https://osi-cwds.atlassian.net/browse/AS-9

## Tests
- [x] I have included unit tests 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the google code style of this project.
- [x] I have ran all tests for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
