### PR TITLE
Hot 1891 screening hoi performance

### DIFF
--- a/src/main/java/gov/ca/cwds/data/persistence/cms/Allegation.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/cms/Allegation.java
@@ -15,7 +15,9 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsExclude;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeExclude;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringExclude;
 import org.hibernate.annotations.ColumnTransformer;
@@ -124,11 +126,15 @@ public class Allegation extends CmsPersistentObject {
    * Doesn't actually load the data. Just checks the existence of the parent referral record.
    * </p>
    */
+  @HashCodeExclude
+  @EqualsExclude
   @ToStringExclude
   @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKCLIENT_T", nullable = false, insertable = false, updatable = false)
   private Client victim;
 
+  @HashCodeExclude
+  @EqualsExclude
   @ToStringExclude
   @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKCLIENT_0", nullable = true, insertable = false, updatable = false)

--- a/src/main/java/gov/ca/cwds/data/persistence/cms/Assignment.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/cms/Assignment.java
@@ -8,13 +8,18 @@ import java.util.Date;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsExclude;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeExclude;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringExclude;
 import org.hibernate.annotations.NamedQuery;
 import org.hibernate.annotations.Type;
 
@@ -103,8 +108,11 @@ public class Assignment extends CmsPersistentObject {
    * Doesn't actually load the data. Just checks the existence of the parent client record.
    * </p>
    */
-  @OneToOne(optional = true)
-  @JoinColumn(name = "ESTBLSH_ID", nullable = true, updatable = false, insertable = false)
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
+  @OneToOne(optional = false, fetch = FetchType.LAZY)
+  @JoinColumn(name = "ESTBLSH_ID", nullable = false, updatable = false, insertable = false)
   private Referral referral;
 
   /**
@@ -264,6 +272,11 @@ public class Assignment extends CmsPersistentObject {
   @Override
   public Serializable getPrimaryKey() {
     return getId();
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this);
   }
 
   @Override

--- a/src/main/java/gov/ca/cwds/data/persistence/cms/ChildClient.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/cms/ChildClient.java
@@ -6,6 +6,7 @@ import java.util.Date;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
@@ -13,7 +14,11 @@ import javax.persistence.PersistenceException;
 import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsExclude;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeExclude;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringExclude;
 import org.hibernate.annotations.NamedQuery;
 import org.hibernate.annotations.Type;
 
@@ -173,7 +178,10 @@ public class ChildClient extends CmsPersistentObject {
    * Doesn't actually load the data. Just checks the existence of the parent client record.
    * </p>
    */
-  @OneToOne(optional = false)
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
+  @OneToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKCLIENT_T", nullable = false, updatable = false, insertable = false)
   private Client client;
 
@@ -654,6 +662,11 @@ public class ChildClient extends CmsPersistentObject {
 
   public Client getClient() {
     return client;
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this);
   }
 
   @Override

--- a/src/main/java/gov/ca/cwds/data/persistence/cms/ClientAddress.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/cms/ClientAddress.java
@@ -14,7 +14,11 @@ import javax.persistence.PersistenceException;
 import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsExclude;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeExclude;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringExclude;
 import org.hibernate.annotations.NamedQuery;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -43,7 +47,10 @@ public class ClientAddress extends BaseClientAddress {
 
   private static final long serialVersionUID = 1L;
 
-  @ManyToOne(cascade = CascadeType.DETACH, optional = false)
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
+  @ManyToOne(cascade = CascadeType.DETACH, optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKADDRS_T", nullable = false, insertable = false, updatable = false)
   private Address addresses;
 
@@ -54,17 +61,13 @@ public class ClientAddress extends BaseClientAddress {
    * referral records.
    * </p>
    */
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
   @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKCLIENT_T", nullable = false, updatable = false, insertable = false)
   private Client client;
 
-  /**
-   * Referential integrity check.
-   * <p>
-   * Doesn't actually load the data. Just checks the existence of the parent address, client and
-   * referral records.
-   * </p>
-   */
   /**
    * Default constructor
    * 
@@ -166,6 +169,11 @@ public class ClientAddress extends BaseClientAddress {
 
   public Client getClient() {
     return client;
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this);
   }
 
   /**

--- a/src/main/java/gov/ca/cwds/data/persistence/cms/ClientCollateral.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/cms/ClientCollateral.java
@@ -4,6 +4,7 @@ import java.util.Date;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -11,7 +12,11 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsExclude;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeExclude;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringExclude;
 import org.hibernate.annotations.ColumnTransformer;
 import org.hibernate.annotations.Type;
 
@@ -70,11 +75,17 @@ public class ClientCollateral extends CmsPersistentObject {
    * Doesn't actually load the data. Just checks the existence of the parent client record.
    * </p>
    */
-  @ManyToOne(optional = false)
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
+  @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKCLIENT_T", nullable = false, updatable = false, insertable = false)
   private Client client;
 
-  @ManyToOne(optional = false)
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
+  @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKCOLTRL_T", nullable = false, updatable = false, insertable = false)
   private CollateralIndividual collateralIndividual;
 
@@ -176,6 +187,11 @@ public class ClientCollateral extends CmsPersistentObject {
   @Override
   public String getPrimaryKey() {
     return getThirdId();
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this);
   }
 
   @Override

--- a/src/main/java/gov/ca/cwds/data/persistence/cms/CmsCase.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/cms/CmsCase.java
@@ -15,7 +15,11 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsExclude;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeExclude;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringExclude;
 import org.hibernate.annotations.NamedNativeQuery;
 import org.hibernate.annotations.NamedQuery;
 import org.hibernate.annotations.NotFound;
@@ -175,12 +179,18 @@ public class CmsCase extends CmsPersistentObject {
   @Column(name = "TICKLE_T_B")
   private String tickleIndVar;
 
-  @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-  @JoinColumn(name = "FKCHLD_CLT", nullable = true, updatable = false, insertable = false)
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
+  @ManyToOne(cascade = CascadeType.ALL, optional = false, fetch = FetchType.LAZY)
+  @JoinColumn(name = "FKCHLD_CLT", nullable = false, updatable = false, insertable = false)
   private ChildClient childClient;
 
-  @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-  @JoinColumn(name = "FKSTFPERST", nullable = true, updatable = false, insertable = false)
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
+  @ManyToOne(cascade = CascadeType.ALL, optional = false, fetch = FetchType.LAZY)
+  @JoinColumn(name = "FKSTFPERST", nullable = false, updatable = false, insertable = false)
   private StaffPerson staffPerson;
 
   /**
@@ -189,6 +199,9 @@ public class CmsCase extends CmsPersistentObject {
    * Doesn't actually load the data. Just checks the existence of the parent client record.
    * </p>
    */
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
   @NotFound(action = NotFoundAction.IGNORE)
   @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKREFERL_T", nullable = true, updatable = false, insertable = false)
@@ -406,6 +419,11 @@ public class CmsCase extends CmsPersistentObject {
 
   public Referral getRiReferral() {
     return riReferral;
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this);
   }
 
   @Override

--- a/src/main/java/gov/ca/cwds/data/persistence/cms/CmsCase.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/cms/CmsCase.java
@@ -22,8 +22,6 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringExclude;
 import org.hibernate.annotations.NamedNativeQuery;
 import org.hibernate.annotations.NamedQuery;
-import org.hibernate.annotations.NotFound;
-import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.Type;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -202,7 +200,6 @@ public class CmsCase extends CmsPersistentObject {
   @HashCodeExclude
   @EqualsExclude
   @ToStringExclude
-  @NotFound(action = NotFoundAction.IGNORE)
   @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKREFERL_T", nullable = true, updatable = false, insertable = false)
   private Referral riReferral;

--- a/src/main/java/gov/ca/cwds/data/persistence/cms/CrossReport.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/cms/CrossReport.java
@@ -6,6 +6,7 @@ import java.util.Date;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -14,7 +15,11 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsExclude;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeExclude;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringExclude;
 import org.hibernate.annotations.Type;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -114,7 +119,10 @@ public class CrossReport extends CmsPersistentObject {
    * Doesn't actually load the data. Just checks the existence of the parent referral record.
    * </p>
    */
-  @ManyToOne(optional = false)
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
+  @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKREFERL_T", nullable = false, updatable = false, insertable = false)
   private Referral referral;
 
@@ -124,7 +132,10 @@ public class CrossReport extends CmsPersistentObject {
    * Doesn't actually load the data. Just checks the existence of the parent referral record.
    * </p>
    */
-  @ManyToOne(optional = true)
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
+  @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKLAW_ENFT", nullable = true, updatable = false, insertable = false)
   private LawEnforcementEntity lawEnforcement;
 
@@ -134,7 +145,10 @@ public class CrossReport extends CmsPersistentObject {
    * Doesn't actually load the data. Just checks the existence of the parent referral record.
    * </p>
    */
-  @ManyToOne(optional = false)
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
+  @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKSTFPERST", nullable = false, updatable = false, insertable = false)
   private StaffPerson staffPerson;
 
@@ -411,6 +425,11 @@ public class CrossReport extends CmsPersistentObject {
 
   public StaffPerson getStaffPerson() {
     return staffPerson;
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this);
   }
 
   @Override

--- a/src/main/java/gov/ca/cwds/data/persistence/cms/GovernmentOrganizationCrossReport.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/cms/GovernmentOrganizationCrossReport.java
@@ -4,6 +4,7 @@ import java.util.Date;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -11,10 +12,14 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsExclude;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.apache.commons.lang3.builder.HashCodeExclude;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringExclude;
 
 /**
  * {@link CmsPersistentObject} Class representing an GovernmentOrganizationCrossReport.
@@ -54,15 +59,24 @@ public class GovernmentOrganizationCrossReport extends CmsPersistentObject {
    * and governmentOrganizationCrossReport record.
    * </p>
    */
-  @ManyToOne(optional = false)
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
+  @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKCRSS_RP0", nullable = false, updatable = false, insertable = false)
   private CrossReport crossReport;
 
-  @ManyToOne(optional = false)
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
+  @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKCRSS_RPT", nullable = false, updatable = false, insertable = false)
   private Referral referral;
 
-  @ManyToOne(optional = true)
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
+  @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKGV_ORG_T", nullable = true, updatable = false, insertable = false)
   private GovernmentOrganizationEntity governmentOrganization;
 
@@ -182,6 +196,11 @@ public class GovernmentOrganizationCrossReport extends CmsPersistentObject {
 
   public GovernmentOrganizationEntity getGovernmentOrganization() {
     return governmentOrganization;
+  }
+
+  @Override
+  public String toString() {
+    return ToStringBuilder.reflectionToString(this);
   }
 
   @Override

--- a/src/main/java/gov/ca/cwds/data/persistence/cms/Referral.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/cms/Referral.java
@@ -21,7 +21,9 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsExclude;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeExclude;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringExclude;
 import org.hibernate.annotations.NamedQuery;
@@ -253,38 +255,58 @@ public class Referral extends CmsPersistentObject implements AccessLimitationAwa
    * Doesn't actually load the data. Just checks the existence of the parent client record.
    * </p>
    */
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
   @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKSTFPERST", nullable = false, updatable = false, insertable = false)
   private StaffPerson staffPerson;
 
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
   @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKSTFPERS0", nullable = true, updatable = false, insertable = false)
   private StaffPerson staffPerson0;
 
-  @ManyToOne(optional = true, fetch = FetchType.LAZY)
-  @JoinColumn(name = "FKREFERL_T", nullable = true, updatable = false, insertable = false)
-  private Referral riReferral;
-
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
   @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "ALGDSC_DOC", nullable = true, updatable = false, insertable = false)
   private DrmsDocument drmsDocument;
 
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
   @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "ER_REF_DOC", nullable = true, updatable = false, insertable = false)
   private DrmsDocument drmsDocument1;
 
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
   @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "INVSTG_DOC", nullable = true, updatable = false, insertable = false)
   private DrmsDocument drmsDocument2;
 
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
   @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "CHILOC_TXT", nullable = true, updatable = false, insertable = false)
   private LongText longText;
 
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
   @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "RSP_RTNTXT", nullable = true, updatable = false, insertable = false)
   private LongText longText1;
 
+  @HashCodeExclude
+  @EqualsExclude
+  @ToStringExclude
   @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "SCN_NT_TXT", nullable = true, updatable = false, insertable = false)
   private LongText longText2;

--- a/src/main/java/gov/ca/cwds/data/persistence/cms/ReferralClient.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/cms/ReferralClient.java
@@ -16,7 +16,9 @@ import javax.persistence.PersistenceException;
 import javax.persistence.Table;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsExclude;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeExclude;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringExclude;
 import org.hibernate.annotations.NamedQuery;
@@ -198,11 +200,15 @@ public class ReferralClient extends CmsPersistentObject {
    * Doesn't actually load the data. Just checks the existence of the parent client record.
    * </p>
    */
+  @HashCodeExclude
+  @EqualsExclude
   @ToStringExclude
   @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKCLIENT_T", nullable = false, updatable = false, insertable = false)
   private Client client;
 
+  @HashCodeExclude
+  @EqualsExclude
   @ToStringExclude
   @ManyToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKREFERL_T", nullable = false, updatable = false, insertable = false)

--- a/src/main/java/gov/ca/cwds/data/persistence/cms/Reporter.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/cms/Reporter.java
@@ -16,7 +16,9 @@ import javax.persistence.Table;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsExclude;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeExclude;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringExclude;
 import org.hibernate.annotations.NamedNativeQuery;
@@ -77,6 +79,8 @@ public class Reporter extends BaseReporter {
    * lawEnforcement and reporterDrmsDocument record.
    * </p>
    */
+  @HashCodeExclude
+  @EqualsExclude
   @ToStringExclude
   @OneToOne(optional = false, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKREFERL_T", nullable = false, updatable = false, insertable = false)
@@ -89,6 +93,8 @@ public class Reporter extends BaseReporter {
    * lawEnforcement and reporterDrmsDocument record.
    * </p>
    */
+  @HashCodeExclude
+  @EqualsExclude
   @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "FKLAW_ENFT", nullable = true, updatable = false, insertable = false)
   private LawEnforcementEntity lawEnforcement;
@@ -100,6 +106,8 @@ public class Reporter extends BaseReporter {
    * lawEnforcement and reporterDrmsDocument record.
    * </p>
    */
+  @HashCodeExclude
+  @EqualsExclude
   @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "FDBACK_DOC", nullable = true, updatable = false, insertable = false)
   private DrmsDocument drmsDocument;


### PR DESCRIPTION
Applied annotations to exclude Referential Integrity Check fields from equals, hashCode, toString.
The changes should help to avoid unnecessary DB queries.
All the DB fields marked with these *exclude annotations are already present in the same or base classes in form of other java properties, so it is safe to exclude their Referential Integrity Check representations from equals and hashCode.

## Jira Issue link
https://osi-cwds.atlassian.net/browse/HOT-1891

## Types of changes
- [x] Refactoring (No behavioral changes)

## Checklist:
- [x] My code follows the google code style of this project.
- [x] I have ran all tests for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
