### PR TITLE
HOT-2062 Correction to Education Provider Contact table and add in Ed…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ applicationDefaultJvmArgs = ["-Djava.library.path=.:./lib:/var/lib/jenkins/works
 
 project.ext {
     apiVersion = '0.7.4'
-    coreApiVersion = '1.7.3_813-RC'
+    coreApiVersion = '1.7.3_814-RC'
     cwdsModelVersion = '0.7.3_593-RC'
     configPath = '$rootProject.projectDir/config/'
     dropwizardVersion = '1.1.0'

--- a/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/EducationProviderContactTransformer.java
+++ b/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/EducationProviderContactTransformer.java
@@ -15,6 +15,7 @@ import gov.ca.cwds.rest.api.domain.IntakeCodeCache;
 import gov.ca.cwds.rest.api.domain.LegacyDescriptor;
 import gov.ca.cwds.rest.api.domain.ParticipantIntakeApi;
 import gov.ca.cwds.rest.api.domain.PhoneNumber;
+import gov.ca.cwds.rest.api.domain.cms.LegacyTable;
 
 /**
  * Business layer object to transform a {@link EducationProviderContact} to an
@@ -31,8 +32,9 @@ public class EducationProviderContactTransformer
 
     LegacyDescriptor educationProviderContactLegacyDescriptor =
         new LegacyDescriptor(educationProviderContact.getId(), null,
-            new DateTime(educationProviderContact.getLastUpdatedTime()), "EDPRVCNT",
-            "Education Provider Contact");
+            new DateTime(educationProviderContact.getLastUpdatedTime()),
+            LegacyTable.EDUCATION_PROVIDER_CONTACT.getName(),
+            LegacyTable.EDUCATION_PROVIDER_CONTACT.getDescription());
 
     String firstName = educationProviderContact.getFirstName();
     String lastName = educationProviderContact.getLastName();
@@ -49,10 +51,10 @@ public class EducationProviderContactTransformer
     String state =
         IntakeCodeCache.global().getIntakeCodeForLegacySystemCode(educationProvider.getStateCd());
 
-    LegacyDescriptor educationProviderLegacyDescriptor =
-        new LegacyDescriptor(educationProvider.getId(), null,
-            new org.joda.time.DateTime(educationProvider.getLastUpdatedTime()), "ED_PVDRT",
-            "Education Provider");
+    LegacyDescriptor educationProviderLegacyDescriptor = new LegacyDescriptor(
+        educationProvider.getId(), null,
+        new org.joda.time.DateTime(educationProvider.getLastUpdatedTime()),
+        LegacyTable.EDUCATION_PROVIDER.getName(), LegacyTable.EDUCATION_PROVIDER.getDescription());
 
     Set<AddressIntakeApi> addresses = new HashSet<>(Arrays
         .asList(new AddressIntakeApi(null, null, streetAddress, educationProvider.getCityName(),

--- a/src/test/java/gov/ca/cwds/rest/business/reminders/R04631ReferralInvestigationContactDueTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/reminders/R04631ReferralInvestigationContactDueTest.java
@@ -1,13 +1,11 @@
 package gov.ca.cwds.rest.business.reminders;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import gov.ca.cwds.data.cms.ReferralClientDao;
-import gov.ca.cwds.data.cms.StateIdDao;
 import java.time.DateTimeException;
 import java.util.Arrays;
 import java.util.Date;
@@ -22,8 +20,10 @@ import org.junit.rules.ExpectedException;
 import gov.ca.cwds.data.cms.AllegationDao;
 import gov.ca.cwds.data.cms.ClientDao;
 import gov.ca.cwds.data.cms.CrossReportDao;
+import gov.ca.cwds.data.cms.ReferralClientDao;
 import gov.ca.cwds.data.cms.ReferralDao;
 import gov.ca.cwds.data.cms.ReporterDao;
+import gov.ca.cwds.data.cms.StateIdDao;
 import gov.ca.cwds.fixture.AddressResourceBuilder;
 import gov.ca.cwds.fixture.AllegationResourceBuilder;
 import gov.ca.cwds.fixture.CrossReportResourceBuilder;
@@ -144,15 +144,15 @@ public class R04631ReferralInvestigationContactDueTest {
     when(allegationDao.find(any(String.class))).thenReturn(savedAllegation);
     when(reporterDao.find(any(String.class))).thenReturn(savedReporter);
     when(crossReportDao.find(any(String.class))).thenReturn(savedCrossReport);
-    R05443AndR03341StateIdMissing r05443AndR03341StateIdMissing =
-        new R05443AndR03341StateIdMissing(clientDao, referralDao, referralClientDao, stateIdDao, tickleService);
+    R05443AndR03341StateIdMissing r05443AndR03341StateIdMissing = new R05443AndR03341StateIdMissing(
+        clientDao, referralDao, referralClientDao, stateIdDao, tickleService);
     R04631ReferralInvestigationContactDue r04631ReferralInvestigationContactDue =
         new R04631ReferralInvestigationContactDue(clientDao, referralDao, tickleService);
 
     r05443AndR03341StateIdMissing.stateIdMissing(postedScreeningToReferral);
     r04631ReferralInvestigationContactDue
         .referralInvestigationContactDue(postedScreeningToReferral);
-    verify(tickleService, times(3)).create(any());
+    verify(tickleService, times(2)).create(any());
   }
 
   /**
@@ -219,8 +219,8 @@ public class R04631ReferralInvestigationContactDueTest {
     when(allegationDao.find(any(String.class))).thenReturn(savedAllegation);
     when(reporterDao.find(any(String.class))).thenReturn(savedReporter);
     when(crossReportDao.find(any(String.class))).thenReturn(savedCrossReport);
-    R05443AndR03341StateIdMissing r05443AndR03341StateIdMissing =
-        new R05443AndR03341StateIdMissing(clientDao, referralDao, referralClientDao, stateIdDao, tickleService);
+    R05443AndR03341StateIdMissing r05443AndR03341StateIdMissing = new R05443AndR03341StateIdMissing(
+        clientDao, referralDao, referralClientDao, stateIdDao, tickleService);
     R04464CrossReportLawEnforcementDue r04464CrossReportLawEnforcementDue =
         new R04464CrossReportLawEnforcementDue(referralDao, allegationDao, reporterDao,
             crossReportDao, tickleService);
@@ -298,8 +298,8 @@ public class R04631ReferralInvestigationContactDueTest {
     when(allegationDao.find(any(String.class))).thenReturn(savedAllegation);
     when(reporterDao.find(any(String.class))).thenReturn(savedReporter);
     when(crossReportDao.find(any(String.class))).thenReturn(savedCrossReport);
-    R05443AndR03341StateIdMissing r05443AndR03341StateIdMissing =
-        new R05443AndR03341StateIdMissing(clientDao, referralDao, referralClientDao, stateIdDao, tickleService);
+    R05443AndR03341StateIdMissing r05443AndR03341StateIdMissing = new R05443AndR03341StateIdMissing(
+        clientDao, referralDao, referralClientDao, stateIdDao, tickleService);
     R04464CrossReportLawEnforcementDue r04464CrossReportLawEnforcementDue =
         new R04464CrossReportLawEnforcementDue(referralDao, allegationDao, reporterDao,
             crossReportDao, tickleService);


### PR DESCRIPTION
…ucation Provider table in api-core class gov.ca.cwds.rest.api.domain.cms.LegacyTable

### JIRA Issue Link
- [HOT-2062:Correction to Education Provider Contact table and add in Education Provider table in api-core class gov.ca.cwds.rest.api.domain.cms.LegacyTable](https://osicwds.atlassian.net/browse/HOT-2062)

### Technical Description
<!---Provide a technical description with context for those that don't know what this pull request is about.-->
refactored to use updated and new Enum from api-core 
### Tests
- [ ] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!---Please indicate why tests were not added.-->
api-core version change
### Types of changes
<!---What types of changes does your code introduce? Put an `x` in all the boxes that apply:-->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Configuration changes
<!---Please list all new configuration parameters introduced by this pull request and describe meaning.-->
<!---Describe impact on automated deployment if any. Put N/A if not applicable.-->
N/A

### Technical debt
<!---If this pull request introduces some technical debt, please describe details and reference JIRA issues created to address this technical debt. Put N/A if not applicable.-->
N/A
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the google code style of this project.
- [x] I have ran all tests for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
