### PR TITLE
HOT-2047 Catch Hibernate Constraint Violation Exception for Referral …

### DIFF
--- a/src/test/java/gov/ca/cwds/rest/services/ParticipantServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/ParticipantServiceTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -26,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.persistence.PersistenceException;
 import javax.validation.Validation;
 import javax.validation.Validator;
 
@@ -37,7 +37,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 
 import gov.ca.cwds.cms.data.access.service.impl.CsecHistoryService;
-import gov.ca.cwds.rest.api.Response;
 import gov.ca.cwds.data.cms.CaseDao;
 import gov.ca.cwds.data.cms.ClientAddressDao;
 import gov.ca.cwds.data.cms.ClientRelationshipDao;
@@ -48,16 +47,14 @@ import gov.ca.cwds.data.cms.TestSystemCodeCache;
 import gov.ca.cwds.data.legacy.cms.dao.SexualExploitationTypeDao;
 import gov.ca.cwds.data.legacy.cms.entity.CsecHistory;
 import gov.ca.cwds.data.legacy.cms.entity.syscodes.SexualExploitationType;
-import gov.ca.cwds.data.legacy.cms.entity.SpecialProjectReferral;
 import gov.ca.cwds.data.rules.TriggerTablesDao;
 import gov.ca.cwds.fixture.ClientEntityBuilder;
 import gov.ca.cwds.fixture.ParticipantResourceBuilder;
 import gov.ca.cwds.fixture.ReporterResourceBuilder;
 import gov.ca.cwds.fixture.SafelySurrenderedBabiesBuilder;
-import gov.ca.cwds.fixture.ScreeningResourceBuilder;
 import gov.ca.cwds.fixture.ScreeningToReferralResourceBuilder;
 import gov.ca.cwds.fixture.SpecialProjectReferralEntityBuilder;
-import gov.ca.cwds.fixture.SpecialProjectReferralResourceBuilder;
+import gov.ca.cwds.rest.api.Response;
 import gov.ca.cwds.rest.api.domain.LegacyDescriptor;
 import gov.ca.cwds.rest.api.domain.Participant;
 import gov.ca.cwds.rest.api.domain.Role;
@@ -71,7 +68,6 @@ import gov.ca.cwds.rest.api.domain.cms.PostedAddress;
 import gov.ca.cwds.rest.api.domain.cms.PostedClient;
 import gov.ca.cwds.rest.api.domain.cms.PostedReporter;
 import gov.ca.cwds.rest.api.domain.cms.Reporter;
-import gov.ca.cwds.rest.api.domain.cms.SpecialProject;
 import gov.ca.cwds.rest.api.domain.error.ErrorMessage;
 import gov.ca.cwds.rest.business.rules.LACountyTrigger;
 import gov.ca.cwds.rest.business.rules.NonLACountyTriggers;
@@ -205,12 +201,13 @@ public class ParticipantServiceTest {
     specialProjectReferralService = mock(SpecialProjectReferralService.class);
 
     specialProjectReferralService = mock(SpecialProjectReferralService.class);
-    gov.ca.cwds.data.legacy.cms.entity.SpecialProjectReferral specialProjectReferral = new SpecialProjectReferralEntityBuilder().build();
-    gov.ca.cwds.rest.api.domain.cms.SpecialProjectReferral postedSpecialProjectReferral = 
+    gov.ca.cwds.data.legacy.cms.entity.SpecialProjectReferral specialProjectReferral =
+        new SpecialProjectReferralEntityBuilder().build();
+    gov.ca.cwds.rest.api.domain.cms.SpecialProjectReferral postedSpecialProjectReferral =
         new gov.ca.cwds.rest.api.domain.cms.SpecialProjectReferral(specialProjectReferral);
     when(specialProjectReferralService.saveCsecSpecialProjectReferral(any(), any(), any(), any()))
-      .thenReturn(postedSpecialProjectReferral);   
-    
+        .thenReturn(postedSpecialProjectReferral);
+
     participantService = new ParticipantService(clientService, referralClientService,
         reporterService, childClientService, clientAddressService, validator,
         clientScpEthnicityService, caseDao, referralClientDao);
@@ -803,12 +800,12 @@ public class ParticipantServiceTest {
         defaultVictim.getSensitivityIndicator(),
         clientArgCaptor.getValue().getSensitivityIndicator());
   }
-  
+
   @Test
   public void shouldReturnNullWhenDelete() {
     Response response = participantService.delete("abc");
     assertThat(response, is(nullValue()));
-   }
+  }
 
   @Test
   public void testSSBIsNotUpdatedForNotSupportedReportType() {
@@ -882,11 +879,42 @@ public class ParticipantServiceTest {
         }));
   }
 
+  @SuppressWarnings("javadoc")
+  @Test(expected = ServiceException.class)
+  public void shouldThrowServiceExceptionWhenUpdateClientThrowsPersistenceException()
+      throws Exception {
+    String victimClientLegacyId = "ABC123DSAF";
+
+    LegacyDescriptor descriptor =
+        new LegacyDescriptor("ABC123DSAF", "", lastUpdateDate, "CLIENT_T", "");
+    Participant victim = new ParticipantResourceBuilder().setLegacyId(victimClientLegacyId)
+        .setLegacyDescriptor(descriptor).createParticipant();
+    Set<Participant> participants =
+        new HashSet<>(Arrays.asList(victim, defaultReporter, defaultPerpetrator));
+
+    ScreeningToReferral referral = new ScreeningToReferralResourceBuilder()
+        .setParticipants(participants).createScreeningToReferral();
+
+    Client foundClient = mock(Client.class);
+    when(foundClient.getLastUpdatedTime()).thenReturn(modifiedLastUpdateDate);
+
+    PostedClient createdClient = mock(PostedClient.class);
+
+    when(createdClient.getId()).thenReturn("LEGACYIDXX");
+    when(clientService.find(eq(victimClientLegacyId))).thenReturn(foundClient);
+    when(clientService.create(any())).thenReturn(createdClient);
+    when(clientService.update(eq(victimClientLegacyId), any()))
+        .thenThrow(new PersistenceException());
+    participantService.saveParticipants(referral, dateStarted, timeStarted, referralId,
+        messageBuilder);
+  }
+
+  @Test
   public void shouldReturnNullWhenFind() {
     Response response = participantService.find("abc");
     assertThat(response, is(nullValue()));
-   }
-  
+  }
+
   @Test
   public void shouldReturnNullWhenUpdate() {
     Response response = participantService.update("abc", null);


### PR DESCRIPTION
…Client

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
The story was to catch Hibernate Constraint Violation Exception for Referral Client. Debugging confirmed that the exception is not directly related to ReferralClientDao. The error is related to Update or Create trying to set a not nullable field as Null. Because of how Hibernate combines and executes queries, the error is thrown at a different spot than where it occurs. Fixed two areas where this type of exception was occuring and added an appropriate error message for similar data related exceptions.
## Jira Issue link
<!--- Provide the link to Jira -->
https://osi-cwds.atlassian.net/browse/HOT-2047 
## Tests
- [x] I have included unit tests 
- [ ] I have included functional tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the google code style of this project.
- [x] I have ran all tests for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
