### PR TITLE
Fix for the participant end point to handle only zip number.

### DIFF
--- a/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/CollateralIndividualTranformer.java
+++ b/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/CollateralIndividualTranformer.java
@@ -65,11 +65,14 @@ public class CollateralIndividualTranformer implements ParticipantMapper<Collate
   }
 
   private String getZip(CollateralIndividual collateralIndividual) {
-    String zip = collateralIndividual.getZipNumber().toString();
-    if (collateralIndividual.getZipSuffixNumber() != null) {
-      return collateralIndividual.getZipNumber() + "-" + collateralIndividual.getZipSuffixNumber();
-    }
-    return zip;
+    return collateralIndividual.getZipNumber().toString();
+    /**
+     * This line can be added once the referrals started accepting zip suffix
+     * 
+     * if (collateralIndividual.getZipSuffixNumber() != null) { return
+     * collateralIndividual.getZipNumber() + "-" + collateralIndividual.getZipSuffixNumber(); }
+     * return zip;
+     */
   }
 
 }

--- a/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/EducationProviderContactTransformer.java
+++ b/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/EducationProviderContactTransformer.java
@@ -74,11 +74,13 @@ public class EducationProviderContactTransformer
   }
 
   private String getZip(EducationProvider educationProvider) {
-    String zip = educationProvider.getZipNumber().toString();
-    if (educationProvider.getZipSuffixNumber() != null) {
-      return educationProvider.getZipNumber() + "-" + educationProvider.getZipSuffixNumber();
-    }
-    return zip;
+    return educationProvider.getZipNumber().toString();
+    /**
+     * This line can be added once the referrals started accepting zip suffix
+     * 
+     * if (educationProvider.getZipSuffixNumber() != null) { return educationProvider.getZipNumber()
+     * + "-" + educationProvider.getZipSuffixNumber(); } return zip;
+     */
   }
 
 }

--- a/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/IntakeAddressConverter.java
+++ b/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/IntakeAddressConverter.java
@@ -62,10 +62,12 @@ public class IntakeAddressConverter {
   }
 
   private String getZip(Address address) {
-    String zip = address.getZip();
-    if (address.getZip4() != null) {
-      return address.getZip() + "-" + address.getZip4();
-    }
-    return zip;
+    return address.getZip();
+    /**
+     * This line can be added once the referrals started accepting zip suffix
+     * 
+     * if (address.getZip4() != null) { return address.getZip() + "-" + address.getZip4(); } return
+     * zip;
+     */
   }
 }

--- a/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/OtherAdultInPlacemtHomeTransformer.java
+++ b/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/OtherAdultInPlacemtHomeTransformer.java
@@ -84,10 +84,12 @@ public class OtherAdultInPlacemtHomeTransformer
   }
 
   private String getZip(PlacementHome placementHome) {
-    String zip = placementHome.getZipNo();
-    if (placementHome.getZipSfxNo() != null) {
-      return placementHome.getZipNo() + "-" + placementHome.getZipSfxNo();
-    }
-    return zip;
+    return placementHome.getZipNo();
+    /**
+     * This line can be added once the referrals started accepting zip suffix
+     * 
+     * if (placementHome.getZipSfxNo() != null) { return placementHome.getZipNo() + "-" +
+     * placementHome.getZipSfxNo(); } return zip;
+     */
   }
 }

--- a/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/OtherChildInPlacemtHomeTransformer.java
+++ b/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/OtherChildInPlacemtHomeTransformer.java
@@ -89,10 +89,12 @@ public class OtherChildInPlacemtHomeTransformer
   }
 
   private String getZip(PlacementHome placementHome) {
-    String zip = placementHome.getZipNo();
-    if (placementHome.getZipSfxNo() != null) {
-      return placementHome.getZipNo() + "-" + placementHome.getZipSfxNo();
-    }
-    return zip;
+    return placementHome.getZipNo();
+    /**
+     * This line can be added once the referrals started accepting zip suffix
+     * 
+     * if (placementHome.getZipSfxNo() != null) { return placementHome.getZipNo() + "-" +
+     * placementHome.getZipSfxNo(); } return zip;
+     */
   }
 }

--- a/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/ReporterTransformer.java
+++ b/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/ReporterTransformer.java
@@ -48,11 +48,13 @@ public class ReporterTransformer implements ParticipantMapper<Reporter> {
   }
 
   private String getZip(Reporter reporter) {
-    String zip = reporter.getZipNumber().toString();
-    if (reporter.getZipSuffixNumber() != null) {
-      return reporter.getZipNumber() + "-" + reporter.getZipSuffixNumber();
-    }
-    return zip;
+    return reporter.getZipNumber().toString();
+    /**
+     * This line can be added once the referrals started accepting zip suffix
+     * 
+     * if (reporter.getZipSuffixNumber() != null) { return reporter.getZipNumber() + "-" +
+     * reporter.getZipSuffixNumber(); }
+     */
   }
 
 }

--- a/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/ServiceProviderTransformer.java
+++ b/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/ServiceProviderTransformer.java
@@ -56,11 +56,13 @@ public class ServiceProviderTransformer implements ParticipantMapper<ServiceProv
   }
 
   private String getZip(ServiceProvider serviceProvider) {
-    String zip = serviceProvider.getZipNumber().toString();
-    if (serviceProvider.getZipSuffixNumber() != null) {
-      return serviceProvider.getZipNumber() + "-" + serviceProvider.getZipSuffixNumber();
-    }
-    return zip;
+    return serviceProvider.getZipNumber().toString();
+    /**
+     * This line can be added once the referrals started accepting zip suffix
+     * 
+     * if (serviceProvider.getZipSuffixNumber() != null) { return serviceProvider.getZipNumber() +
+     * "-" + serviceProvider.getZipSuffixNumber(); }
+     */
   }
 
 }

--- a/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/SubstituteCareProviderTransformer.java
+++ b/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/SubstituteCareProviderTransformer.java
@@ -59,12 +59,13 @@ public class SubstituteCareProviderTransformer
   }
 
   private String getZip(SubstituteCareProvider substituteCareProvider) {
-    String zip = substituteCareProvider.getZipNumber().toString();
-    if (substituteCareProvider.getZipSuffixNumber() != null) {
-      return substituteCareProvider.getZipNumber() + "-"
-          + substituteCareProvider.getZipSuffixNumber();
-    }
-    return zip;
+    return substituteCareProvider.getZipNumber().toString();
+    /**
+     * This line can be added once the referrals started accepting zip suffix
+     * 
+     * if (substituteCareProvider.getZipSuffixNumber() != null) { return
+     * substituteCareProvider.getZipNumber() + "-" + substituteCareProvider.getZipSuffixNumber(); }
+     */
   }
 
 }

--- a/src/test/java/gov/ca/cwds/rest/services/screeningparticipant/CollateralIndividualTranformerTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/screeningparticipant/CollateralIndividualTranformerTest.java
@@ -89,7 +89,7 @@ public class CollateralIndividualTranformerTest {
         LegacyTable.COLLATERAL_INDIVIDUAL.getName(),
         LegacyTable.COLLATERAL_INDIVIDUAL.getDescription());
     Set<AddressIntakeApi> addresses = new HashSet<>(Arrays.asList(new AddressIntakeApi(null, null,
-        "2751 West River", "Sacramento", "CA", "95833-7812", null, legacyDescriptor)));
+        "2751 West River", "Sacramento", "CA", "95833", null, legacyDescriptor)));
     Set<PhoneNumber> phoneNumbers = new HashSet<>(Arrays.asList(new PhoneNumber(null, "1", null)));
     ParticipantIntakeApi expected =
         new ParticipantIntakeApi(null, null, null, legacyDescriptor, "firstName", "middleName",

--- a/src/test/java/gov/ca/cwds/rest/services/screeningparticipant/EducationProviderContactTransformerTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/screeningparticipant/EducationProviderContactTransformerTest.java
@@ -88,7 +88,7 @@ public class EducationProviderContactTransformerTest {
     LegacyDescriptor addressLegacyDescriptor =
         new LegacyDescriptor("fk12345678", null, lastUpdated, "ED_PVDRT", "Education Provider");
     Set<AddressIntakeApi> addresses = new HashSet<>(Arrays.asList(new AddressIntakeApi(null, null,
-        "streetNumber streetName", "Sacramento", "CA", "99999-0", null, addressLegacyDescriptor)));
+        "streetNumber streetName", "Sacramento", "CA", "99999", null, addressLegacyDescriptor)));
     Set<PhoneNumber> phoneNumbers = new HashSet<>(Arrays.asList(new PhoneNumber(null, "0", null)));
     ParticipantIntakeApi expected =
         new ParticipantIntakeApi(null, null, null, legacyDescriptor, "Firstname", "Middle",

--- a/src/test/java/gov/ca/cwds/rest/services/screeningparticipant/OtherAdultInPlacemtHomeTransformerTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/screeningparticipant/OtherAdultInPlacemtHomeTransformerTest.java
@@ -102,7 +102,7 @@ public class OtherAdultInPlacemtHomeTransformerTest {
         LegacyTable.PLACEMENT_HOME.getName(), LegacyTable.PLACEMENT_HOME.getDescription());
 
     Set<AddressIntakeApi> addresses = new HashSet<>(Arrays.asList(new AddressIntakeApi(null, null,
-        "streetNumber streetName", "Sacramento", "CA", "99999-0", null, addressLegacyDescriptor)));
+        "streetNumber streetName", "Sacramento", "CA", "99999", null, addressLegacyDescriptor)));
     Set<PhoneNumber> phoneNumbers = null;
     ParticipantIntakeApi expected =
         new ParticipantIntakeApi(null, null, null, legacyDescriptor, "Karen", null, "Q", null, "M",

--- a/src/test/java/gov/ca/cwds/rest/services/screeningparticipant/OtherChildInPlacemtHomeTransformerTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/screeningparticipant/OtherChildInPlacemtHomeTransformerTest.java
@@ -118,7 +118,7 @@ public class OtherChildInPlacemtHomeTransformerTest {
         LegacyTable.PLACEMENT_HOME.getName(), LegacyTable.PLACEMENT_HOME.getDescription());
 
     Set<AddressIntakeApi> addresses = new HashSet<>(Arrays.asList(new AddressIntakeApi(null, null,
-        "streetNumber streetName", "Sacramento", "CA", "99999-0", null, addressLegacyDescriptor)));
+        "streetNumber streetName", "Sacramento", "CA", "99999", null, addressLegacyDescriptor)));
     Set<PhoneNumber> phoneNumbers = null;
     ParticipantIntakeApi expected = new ParticipantIntakeApi(null, null, null, legacyDescriptor,
         "aaa", null, "bbb", null, "male", null, null, null, new Date(), null, new LinkedList<>(),

--- a/src/test/java/gov/ca/cwds/rest/services/screeningparticipant/ReporterTransformerTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/screeningparticipant/ReporterTransformerTest.java
@@ -79,7 +79,7 @@ public class ReporterTransformerTest {
     LegacyDescriptor legacyDescriptor = new LegacyDescriptor("Abc0987654", null, lastUpdated,
         LegacyTable.REPORTER.getName(), LegacyTable.REPORTER.getDescription());
     Set<AddressIntakeApi> addresses = new HashSet<>(Arrays.asList(new AddressIntakeApi(null, null,
-        "2751 First Street", "Sacramento", "CA", "95833-0", null, legacyDescriptor)));
+        "2751 First Street", "Sacramento", "CA", "95833", null, legacyDescriptor)));
     Set<PhoneNumber> phoneNumbers =
         new HashSet<>(Arrays.asList(new PhoneNumber(null, "6199221167", null)));
     ParticipantIntakeApi expected = new ParticipantIntakeApi(null, null, null, legacyDescriptor,

--- a/src/test/java/gov/ca/cwds/rest/services/screeningparticipant/ServiceProviderTransformerTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/screeningparticipant/ServiceProviderTransformerTest.java
@@ -91,7 +91,7 @@ public class ServiceProviderTransformerTest {
     LegacyDescriptor legacyDescriptor = new LegacyDescriptor("Ao9dm8T0Ki", null, lastUpdated,
         LegacyTable.SERVICE_PROVIDER.getName(), LegacyTable.SERVICE_PROVIDER.getDescription());
     Set<AddressIntakeApi> addresses = new HashSet<>(Arrays.asList(new AddressIntakeApi(null, null,
-        "streetNumber streetName", "Sacramento", "CA", "99999-0", null, legacyDescriptor)));
+        "streetNumber streetName", "Sacramento", "CA", "99999", null, legacyDescriptor)));
     Set<PhoneNumber> phoneNumbers =
         new HashSet<>(Arrays.asList(new PhoneNumber(null, "999", null)));
     ParticipantIntakeApi expected =

--- a/src/test/java/gov/ca/cwds/rest/services/screeningparticipant/SubstituteCareProviderTransformerTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/screeningparticipant/SubstituteCareProviderTransformerTest.java
@@ -93,7 +93,7 @@ public class SubstituteCareProviderTransformerTest {
         LegacyTable.SUBSTITUTE_CARE_PROVIDER.getName(),
         LegacyTable.SUBSTITUTE_CARE_PROVIDER.getDescription());
     Set<AddressIntakeApi> addresses = new HashSet<>(Arrays.asList(new AddressIntakeApi(null, null,
-        "Number 5th St", "Sacramento", "CA", "95814-0", null, legacyDescriptor)));
+        "Number 5th St", "Sacramento", "CA", "95814", null, legacyDescriptor)));
     Set<PhoneNumber> phoneNumbers = new HashSet<>(Arrays.asList(new PhoneNumber(null, "0", null)));
     ParticipantIntakeApi expected = new ParticipantIntakeApi(null, null, null, legacyDescriptor,
         "Fish", "N", "Tuna", "Description", null, null, null, "000994415",


### PR DESCRIPTION
## Description
Refactored the Participant endpoint POST to accept only Zip number and ignore the zip suffix. As screening to referral service is accepting only zip number present. Later in future, we can add back the commented file when we add the zip suffix to intake.

## Jira Issue link
No Story

## Tests
- [x] I have included unit tests 
- [ ] I have included functional tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the google code style of this project.
- [x] I have ran all tests for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
