### PR TITLE
Safey Alerts are added to Screener Alert Text

### DIFF
--- a/src/main/java/gov/ca/cwds/rest/resources/ScreeningRelationshipResource.java
+++ b/src/main/java/gov/ca/cwds/rest/resources/ScreeningRelationshipResource.java
@@ -2,7 +2,21 @@ package gov.ca.cwds.rest.resources;
 
 import static gov.ca.cwds.rest.core.Api.SCREENING_RELATIONSHIPS;
 
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.http.HttpStatus;
+
 import com.google.inject.Inject;
+
 import gov.ca.cwds.inject.ScreeningRelationshipServiceBackedResource;
 import gov.ca.cwds.rest.api.domain.ScreeningRelationship;
 import io.dropwizard.hibernate.UnitOfWork;
@@ -11,23 +25,13 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import javax.validation.Valid;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.GET;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import org.apache.http.HttpStatus;
 
 /**
  * A resource providing a RESTful interface for {@link ScreeningRelationshipResource}. It delegates
- * functions to {@link ServiceBackedResourceDelegate}. It decorates the {@link
- * ServiceBackedResourceDelegate} not in functionality but with @see <a href=
- * "https://github.com/swagger-api/swagger-core/wiki/Annotations-1.5.X">Swagger Annotations</a> and
+ * functions to {@link ServiceBackedResourceDelegate}. It decorates the
+ * {@link ServiceBackedResourceDelegate} not in functionality but with @see
+ * <a href= "https://github.com/swagger-api/swagger-core/wiki/Annotations-1.5.X">Swagger
+ * Annotations</a> and
  * <a href="https://jersey.java.net/documentation/latest/user-guide.html#jaxrs-resources">Jersey
  * Annotations</a>
  *
@@ -61,16 +65,17 @@ public class ScreeningRelationshipResource {
   @UnitOfWork(value = "ns")
   @POST
   @Consumes(value = MediaType.APPLICATION_JSON)
-  @ApiResponses(value = {
-      @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = "Unable to process JSON"),
-      @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = "Not Authorized"),
-      @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "Accept Header not supported"),
-      @ApiResponse(code = HttpStatus.SC_UNPROCESSABLE_ENTITY, message = "Unable to validate ScreeningRelationship"),
-      @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "Not found")})
+  @ApiResponses(
+      value = {@ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = "Unable to process JSON"),
+          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = "Not Authorized"),
+          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "Accept Header not supported"),
+          @ApiResponse(code = HttpStatus.SC_UNPROCESSABLE_ENTITY,
+              message = "Unable to validate ScreeningRelationship"),
+          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "Not found")})
   @ApiOperation(value = "Create Screening Relationship", code = HttpStatus.SC_CREATED,
       response = ScreeningRelationship.class)
-  public Response create(@Valid @ApiParam(hidden = false, required = true)
-      ScreeningRelationship screeningRelationship) {
+  public Response create(@Valid @ApiParam(hidden = false,
+      required = true) ScreeningRelationship screeningRelationship) {
     return resourceDelegate.create(screeningRelationship);
   }
 
@@ -78,34 +83,43 @@ public class ScreeningRelationshipResource {
    * Update an {@link ScreeningRelationship}.
    *
    * @param screeningRelationship The {@link ScreeningRelationship}
+   * @param id - id
    * @return The {@link Response}
    */
   @UnitOfWork(value = "ns")
   @PUT
   @Path("/{id}")
   @Consumes(value = MediaType.APPLICATION_JSON)
-  @ApiResponses(value = {
-      @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = "Unable to process JSON"),
-      @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = "Not Authorized"),
-      @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "Accept Header not supported"),
-      @ApiResponse(code = HttpStatus.SC_UNPROCESSABLE_ENTITY, message = "Unable to validate ScreeningRelationship"),
-      @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "Not found")})
+  @ApiResponses(
+      value = {@ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = "Unable to process JSON"),
+          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = "Not Authorized"),
+          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "Accept Header not supported"),
+          @ApiResponse(code = HttpStatus.SC_UNPROCESSABLE_ENTITY,
+              message = "Unable to validate ScreeningRelationship"),
+          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "Not found")})
   @ApiOperation(value = "Create Screening Relationship", code = HttpStatus.SC_CREATED,
       response = ScreeningRelationship.class)
-  public Response update(@Valid @ApiParam(hidden = false, required = true)
-      ScreeningRelationship screeningRelationship, @PathParam("id") @ApiParam(required = true,
-      value = "The id of the Relationship to find") String id) {
+  public Response update(
+      @Valid @ApiParam(hidden = false, required = true) ScreeningRelationship screeningRelationship,
+      @PathParam("id") @ApiParam(required = true,
+          value = "The id of the Relationship to find") String id) {
     return resourceDelegate.update(id, screeningRelationship);
   }
 
+  /**
+   * Get an {@link ScreeningRelationship}.
+   * 
+   * @param id - id
+   * @return The {@link Response}
+   */
   @UnitOfWork(value = "ns")
   @GET
   @Path("/{id}")
-  @ApiResponses(value = {
-      @ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = "Unable to process JSON"),
-      @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = "Not Authorized"),
-      @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "Accept Header not supported"),
-      @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "Relationship not found")})
+  @ApiResponses(
+      value = {@ApiResponse(code = HttpStatus.SC_BAD_REQUEST, message = "Unable to process JSON"),
+          @ApiResponse(code = HttpStatus.SC_UNAUTHORIZED, message = "Not Authorized"),
+          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "Accept Header not supported"),
+          @ApiResponse(code = HttpStatus.SC_NOT_FOUND, message = "Relationship not found")})
   @ApiOperation(value = "Find Relationship by id", code = HttpStatus.SC_OK,
       response = ScreeningRelationship.class)
   public Response get(@PathParam("id") @ApiParam(required = true,

--- a/src/main/java/gov/ca/cwds/rest/services/CachingIntakeCodeService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/CachingIntakeCodeService.java
@@ -48,6 +48,7 @@ public class CachingIntakeCodeService extends IntakeLovService implements Intake
    * 
    * @param intakeLovDao Intake Lov Dao
    * @param secondsToRefreshCache Seconds after which cache entries will be invalidated for refresh.
+   * @param preloadCache If true then preload all system code cache
    */
   @Inject
   public CachingIntakeCodeService(IntakeLovDao intakeLovDao, long secondsToRefreshCache,

--- a/src/main/java/gov/ca/cwds/rest/services/ReferralSafetyAlertsService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/ReferralSafetyAlertsService.java
@@ -14,17 +14,20 @@ import gov.ca.cwds.data.legacy.cms.entity.LongText;
 import gov.ca.cwds.data.legacy.cms.entity.SafetyAlert;
 import gov.ca.cwds.data.persistence.cms.Referral;
 import gov.ca.cwds.rest.api.domain.Participant;
+import gov.ca.cwds.rest.api.domain.Screening;
 import gov.ca.cwds.rest.api.domain.ScreeningToReferral;
 import gov.ca.cwds.rest.api.domain.cms.SystemCode;
 import gov.ca.cwds.rest.api.domain.cms.SystemCodeCache;
 import gov.ca.cwds.rest.util.ParticipantUtils;
 
 /***
+ * This class is not longer used to save the safety Alerts for {@link Screening}, But can be used
+ * later once we start saving it {@link SafetyAlert} table.
  * 
  * @author CWDS API Team
  *
  */
-public class ReferralSatefyAlertsService {
+public class ReferralSafetyAlertsService {
 
   @Inject
   private ReferralDao referralDao;

--- a/src/main/java/gov/ca/cwds/rest/services/ScreeningToReferralService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/ScreeningToReferralService.java
@@ -73,7 +73,6 @@ public class ScreeningToReferralService implements CrudsService {
 
   private ReferralDao referralDao;
   private ClientRelationshipDao clientRelationshipDao;
-  private ReferralSatefyAlertsService referralSatefyAlertsService;
 
   /**
    * Constructor
@@ -100,8 +99,7 @@ public class ScreeningToReferralService implements CrudsService {
       ReferralDao referralDao, MessageBuilder messageBuilder,
       AllegationPerpetratorHistoryService allegationPerpetratorHistoryService, Reminders reminders,
       GovernmentOrganizationCrossReportService governmentOrganizationCrossReportService,
-      ClientRelationshipDao clientRelationshipDao,
-      ReferralSatefyAlertsService referralSatefyAlertsService) {
+      ClientRelationshipDao clientRelationshipDao) {
 
     super();
     this.clientRelationshipDao = clientRelationshipDao;
@@ -116,7 +114,6 @@ public class ScreeningToReferralService implements CrudsService {
     this.allegationPerpetratorHistoryService = allegationPerpetratorHistoryService;
     this.reminders = reminders;
     this.governmentOrganizationCrossReportService = governmentOrganizationCrossReportService;
-    this.referralSatefyAlertsService = referralSatefyAlertsService;
   }
 
   @UnitOfWork(value = "cms")
@@ -152,7 +149,6 @@ public class ScreeningToReferralService implements CrudsService {
     Set<Allegation> resultAllegations = createAllegations(screeningToReferral, referralId,
         clientParticipants.getVictimIds(), clientParticipants.getPerpetratorIds());
 
-    referralSatefyAlertsService.create(screeningToReferral, referralId, clientParticipants);
     PostedScreeningToReferral pstr =
         PostedScreeningToReferral.createWithDefaults(referralId, screeningToReferral,
             clientParticipants.getParticipants(), resultCrossReports, resultAllegations);

--- a/src/main/java/gov/ca/cwds/rest/services/ScreeningToReferralService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/ScreeningToReferralService.java
@@ -89,7 +89,6 @@ public class ScreeningToReferralService implements CrudsService {
    * @param reminders reminders
    * @param governmentOrganizationCrossReportService governmentOrganizationCrossReportService
    * @param clientRelationshipDao clientRelationshipDao
-   * @param referralSatefyAlertsService referralSatefyAlertsService
    */
   @Inject
   public ScreeningToReferralService(ReferralService referralService,

--- a/src/main/java/gov/ca/cwds/rest/services/submit/SafetyAlertsInformation.java
+++ b/src/main/java/gov/ca/cwds/rest/services/submit/SafetyAlertsInformation.java
@@ -19,7 +19,7 @@ public class SafetyAlertsInformation {
     StringBuilder stringBuilder = new StringBuilder();
     if (screening.getSafetyAlerts() != null && !screening.getSafetyAlerts().isEmpty()
         && StringUtils.isNotBlank(screening.getSafetyInformation())) {
-      screening.getSafetyAlerts().forEach(alert -> stringBuilder.append(alert).append(","));
+      screening.getSafetyAlerts().forEach(alert -> stringBuilder.append(alert).append(','));
       stringBuilder.append(screening.getSafetyInformation());
       return stringBuilder.toString();
     } else if (screening.getSafetyAlerts() == null && screening.getSafetyAlerts().isEmpty()
@@ -27,7 +27,7 @@ public class SafetyAlertsInformation {
       return screening.getSafetyInformation();
     } else if (screening.getSafetyAlerts() != null && !screening.getSafetyAlerts().isEmpty()
         && StringUtils.isBlank(screening.getSafetyInformation())) {
-      screening.getSafetyAlerts().forEach(alert -> stringBuilder.append(alert).append(","));
+      screening.getSafetyAlerts().forEach(alert -> stringBuilder.append(alert).append(','));
       return stringBuilder.substring(0, stringBuilder.length() - 1);
     }
     return safetyInformation;

--- a/src/main/java/gov/ca/cwds/rest/services/submit/SafetyAlertsInformation.java
+++ b/src/main/java/gov/ca/cwds/rest/services/submit/SafetyAlertsInformation.java
@@ -1,0 +1,38 @@
+package gov.ca.cwds.rest.services.submit;
+
+import org.apache.commons.lang3.StringUtils;
+
+import gov.ca.cwds.rest.api.domain.Screening;
+
+/**
+ * @author CWDS API Team
+ *
+ */
+public class SafetyAlertsInformation {
+
+  /**
+   * @param screening - screening
+   * @return the safetyInformation
+   */
+  public String buildSafetyAlertsInfo(Screening screening) {
+    String safetyInformation = null;
+    StringBuilder stringBuilder = new StringBuilder();
+    if (screening.getSafetyAlerts() != null && !screening.getSafetyAlerts().isEmpty()
+        && StringUtils.isNotBlank(screening.getSafetyInformation())) {
+      screening.getSafetyAlerts().forEach(alert -> stringBuilder.append(alert).append(","));
+      stringBuilder.append(screening.getSafetyInformation());
+      return stringBuilder.toString();
+    } else if (screening.getSafetyAlerts() == null && screening.getSafetyAlerts().isEmpty()
+        && StringUtils.isNotBlank(screening.getSafetyInformation())) {
+      return screening.getSafetyInformation();
+    } else if (screening.getSafetyAlerts() != null && !screening.getSafetyAlerts().isEmpty()
+        && StringUtils.isBlank(screening.getSafetyInformation())) {
+      screening.getSafetyAlerts().forEach(alert -> stringBuilder.append(alert).append(","));
+      return stringBuilder.substring(0, stringBuilder.length() - 1);
+    }
+    return safetyInformation;
+  }
+
+}
+
+

--- a/src/main/java/gov/ca/cwds/rest/services/submit/ScreeningTransformer.java
+++ b/src/main/java/gov/ca/cwds/rest/services/submit/ScreeningTransformer.java
@@ -48,6 +48,7 @@ public class ScreeningTransformer {
       String loggedInStaffCounty) {
     Set<Allegation> allegations =
         new AllegationsTransformer().transform(screening.getAllegations());
+    String safetyAlertsInformation = new SafetyAlertsInformation().buildSafetyAlertsInfo(screening);
     Short communicationMethodSysId = setCommunicationMethod(screening);
     Short responseTimeSysId = setReferralResponse(screening);
     String limitedAccessCode = StringUtils.isNotBlank(screening.getAccessRestrictions())
@@ -83,9 +84,9 @@ public class ScreeningTransformer {
         screening.getAdditionalInformation(), screening.getScreeningDecision(),
         screening.getScreeningDecisionDetail(), APPROVAL_STATUS, FAMILY_AWARENESS,
         FILED_WITH_LAW_ENFORCEMENT, RESPONSIBLE_AGENCY, limitedAccessCode,
-        screening.getRestrictionsRationale(), loggedInStaffCounty, limitedAccessDate,
-        convertSafetyAlerts(screening), screening.getSafetyInformation(), address, participants,
-        new HashSet<ScreeningRelationship>(), crossReports, allegations, screening.getReportType());
+        screening.getRestrictionsRationale(), loggedInStaffCounty, limitedAccessDate, null,
+        safetyAlertsInformation, address, participants, new HashSet<ScreeningRelationship>(),
+        crossReports, allegations, screening.getReportType());
   }
 
   private Short setReferralResponse(Screening screening) {
@@ -106,18 +107,6 @@ public class ScreeningTransformer {
     return screening.getRestrictionsDate() != null
         ? java.sql.Date.valueOf(screening.getRestrictionsDate())
         : null;
-  }
-
-  private Set<Short> convertSafetyAlerts(Screening screening) {
-    Set<Short> safetAlerts = new HashSet<>();
-    if (!screening.getSafetyAlerts().isEmpty()) {
-      for (String intakeCode : screening.getSafetyAlerts()) {
-        Short safetyAlert = IntakeCodeCache.global()
-            .getLegacySystemCodeForIntakeCode(SystemCodeCategoryId.SAFETY_ALERTS, intakeCode);
-        safetAlerts.add(safetyAlert);
-      }
-    }
-    return safetAlerts;
   }
 
 }

--- a/src/test/java/gov/ca/cwds/fixture/MockedScreeningToReferralServiceBuilder.java
+++ b/src/test/java/gov/ca/cwds/fixture/MockedScreeningToReferralServiceBuilder.java
@@ -30,7 +30,6 @@ import gov.ca.cwds.rest.api.domain.cms.Reporter;
 import gov.ca.cwds.rest.business.rules.Reminders;
 import gov.ca.cwds.rest.messages.MessageBuilder;
 import gov.ca.cwds.rest.services.ParticipantService;
-import gov.ca.cwds.rest.services.ReferralSatefyAlertsService;
 import gov.ca.cwds.rest.services.ScreeningToReferralService;
 import gov.ca.cwds.rest.services.cms.AddressService;
 import gov.ca.cwds.rest.services.cms.AllegationPerpetratorHistoryService;
@@ -68,7 +67,6 @@ public class MockedScreeningToReferralServiceBuilder {
   private ClientRelationshipDao clientRelationshipDao;
   private ReferralDao referralDao;
   private MessageBuilder messageBuilder;
-  private ReferralSatefyAlertsService referralSatefyAlertsService;
 
   /**
    * @return the referralService
@@ -283,20 +281,6 @@ public class MockedScreeningToReferralServiceBuilder {
   }
 
   /**
-   * @return the referralSatefyAlertsService
-   */
-  public ReferralSatefyAlertsService getScreeningSatefyAlertsService() {
-    if (referralSatefyAlertsService == null) {
-      buildDefaultMockForReferralSafetyAlertsService();
-    }
-    return referralSatefyAlertsService;
-  }
-
-  private void buildDefaultMockForReferralSafetyAlertsService() {
-    referralSatefyAlertsService = mock(ReferralSatefyAlertsService.class);
-  }
-
-  /**
    * 
    * @return the mocked assignmentService
    */
@@ -485,7 +469,6 @@ public class MockedScreeningToReferralServiceBuilder {
         getCrossReportService(), getParticipantService(), clientRelationshipService,
         Validation.buildDefaultValidatorFactory().getValidator(), getReferralDao(),
         getMessageBuilder(), getAllegationPerpetratorHistoryService(), getReminders(),
-        getGovernmentOrganizationCrossReportService(), getClientRelationshipDao(),
-        getScreeningSatefyAlertsService());
+        getGovernmentOrganizationCrossReportService(), getClientRelationshipDao());
   }
 }

--- a/src/test/java/gov/ca/cwds/rest/business/rules/R00797SensitiveReferralAssignmentTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/R00797SensitiveReferralAssignmentTest.java
@@ -74,7 +74,6 @@ import gov.ca.cwds.rest.filters.TestingRequestExecutionContext;
 import gov.ca.cwds.rest.messages.MessageBuilder;
 import gov.ca.cwds.rest.services.ClientParticipants;
 import gov.ca.cwds.rest.services.ParticipantService;
-import gov.ca.cwds.rest.services.ReferralSatefyAlertsService;
 import gov.ca.cwds.rest.services.ScreeningToReferralService;
 import gov.ca.cwds.rest.services.cms.AddressService;
 import gov.ca.cwds.rest.services.cms.AllegationPerpetratorHistoryService;
@@ -164,7 +163,6 @@ public class R00797SensitiveReferralAssignmentTest {
   private CwsOfficeDao cwsOfficeDao;
   private MessageBuilder messageBuilder;
   private ClientRelationshipDao clientRelationshipDao;
-  private ReferralSatefyAlertsService referralSatefyAlertsService;
 
   private gov.ca.cwds.data.persistence.cms.Referral referral;
   private Validator validator;
@@ -261,7 +259,6 @@ public class R00797SensitiveReferralAssignmentTest {
     clientRelationshipService = mock(ClientRelationshipCoreService.class);
 
     governmentOrganizationCrossReportService = mock(GovernmentOrganizationCrossReportService.class);
-    referralSatefyAlertsService = mock(ReferralSatefyAlertsService.class);
 
     referralService =
         new ReferralService(referralDao, nonLACountyTriggers, laCountyTrigger, triggerTablesDao,
@@ -271,8 +268,7 @@ public class R00797SensitiveReferralAssignmentTest {
     screeningToReferralService = new ScreeningToReferralService(referralService, allegationService,
         crossReportService, participantService, clientRelationshipService, validator, referralDao,
         new MessageBuilder(), allegationPerpetratorHistoryService, reminders,
-        governmentOrganizationCrossReportService, clientRelationshipDao,
-        referralSatefyAlertsService);
+        governmentOrganizationCrossReportService, clientRelationshipDao);
   }
 
   /**

--- a/src/test/java/gov/ca/cwds/rest/business/rules/doctool/LastUpdatedTimeIsUniqueTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/doctool/LastUpdatedTimeIsUniqueTest.java
@@ -73,7 +73,6 @@ import gov.ca.cwds.rest.business.rules.UpperCaseTables;
 import gov.ca.cwds.rest.filters.TestingRequestExecutionContext;
 import gov.ca.cwds.rest.messages.MessageBuilder;
 import gov.ca.cwds.rest.services.ParticipantService;
-import gov.ca.cwds.rest.services.ReferralSatefyAlertsService;
 import gov.ca.cwds.rest.services.ScreeningToReferralService;
 import gov.ca.cwds.rest.services.cms.AddressService;
 import gov.ca.cwds.rest.services.cms.AllegationPerpetratorHistoryService;
@@ -134,7 +133,6 @@ public class LastUpdatedTimeIsUniqueTest {
   private RIReferral riReferral;
   private RIReferralClient riReferralClient;
   private GovernmentOrganizationCrossReportService governmentOrganizationCrossReportService;
-  private ReferralSatefyAlertsService screeningSatefyAlertsService;
 
   private ReferralDao referralDao;
   private ClientDao clientDao;
@@ -285,7 +283,6 @@ public class LastUpdatedTimeIsUniqueTest {
     participantService = new ParticipantService(clientService, referralClientService,
         reporterService, childClientService, clientAddressService, validator,
         clientScpEthnicityService, caseDao, referralClientDao);
-    screeningSatefyAlertsService = mock(ReferralSatefyAlertsService.class);
     clientRelationshipService = mock(ClientRelationshipCoreService.class);
 
     referralService =
@@ -297,7 +294,7 @@ public class LastUpdatedTimeIsUniqueTest {
         crossReportService, participantService, clientRelationshipService,
         Validation.buildDefaultValidatorFactory().getValidator(), referralDao, new MessageBuilder(),
         allegationPerpetratorHistoryService, reminders, governmentOrganizationCrossReportService,
-        clientRelationshipDao, screeningSatefyAlertsService);
+        clientRelationshipDao);
   }
 
   /**

--- a/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R00796ScreeningToReferralDeleteTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R00796ScreeningToReferralDeleteTest.java
@@ -40,7 +40,6 @@ import gov.ca.cwds.rest.business.rules.UpperCaseTables;
 import gov.ca.cwds.rest.filters.TestingRequestExecutionContext;
 import gov.ca.cwds.rest.messages.MessageBuilder;
 import gov.ca.cwds.rest.services.ParticipantService;
-import gov.ca.cwds.rest.services.ReferralSatefyAlertsService;
 import gov.ca.cwds.rest.services.ScreeningToReferralService;
 import gov.ca.cwds.rest.services.cms.AddressService;
 import gov.ca.cwds.rest.services.cms.AllegationPerpetratorHistoryService;
@@ -101,7 +100,6 @@ public class R00796ScreeningToReferralDeleteTest {
   private RIReferral riReferral;
   private RIReferralClient riReferralClient;
   private GovernmentOrganizationCrossReportService governmentOrganizationCrossReportService;
-  private ReferralSatefyAlertsService referralSatefyAlertsService;
 
   private ReferralDao referralDao;
   private ClientDao clientDao;
@@ -224,14 +222,13 @@ public class R00796ScreeningToReferralDeleteTest {
     participantService = mock(ParticipantService.class);
     clientRelationshipService = mock(ClientRelationshipCoreService.class);
     governmentOrganizationCrossReportService = mock(GovernmentOrganizationCrossReportService.class);
-    referralSatefyAlertsService = mock(ReferralSatefyAlertsService.class);
     reminders = mock(Reminders.class);
 
     screeningToReferralService = new ScreeningToReferralService(referralService, allegationService,
         crossReportService, participantService, clientRelationshipService,
         Validation.buildDefaultValidatorFactory().getValidator(), referralDao, new MessageBuilder(),
         allegationPerpetratorHistoryService, reminders, governmentOrganizationCrossReportService,
-        clientRelationshipDao, referralSatefyAlertsService);
+        clientRelationshipDao);
   }
 
   /**

--- a/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R04537FirstResponseDeterminedByStaffPersonIdTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R04537FirstResponseDeterminedByStaffPersonIdTest.java
@@ -83,7 +83,6 @@ import gov.ca.cwds.rest.filters.TestingRequestExecutionContext;
 import gov.ca.cwds.rest.messages.MessageBuilder;
 import gov.ca.cwds.rest.services.ClientParticipants;
 import gov.ca.cwds.rest.services.ParticipantService;
-import gov.ca.cwds.rest.services.ReferralSatefyAlertsService;
 import gov.ca.cwds.rest.services.ScreeningToReferralService;
 import gov.ca.cwds.rest.services.cms.AddressService;
 import gov.ca.cwds.rest.services.cms.AllegationPerpetratorHistoryService;
@@ -145,7 +144,6 @@ public class R04537FirstResponseDeterminedByStaffPersonIdTest {
   private RIReferralClient riReferralClient;
   private GovernmentOrganizationCrossReportService governmentOrganizationCrossReportService;
   private ClientRelationshipDao clientRelationshipDao;
-  private ReferralSatefyAlertsService referralSatefyAlertsService;
 
   private ReferralDao referralDao;
   private ClientDao clientDao;
@@ -280,7 +278,6 @@ public class R04537FirstResponseDeterminedByStaffPersonIdTest {
 
     clientRelationshipService = mock(ClientRelationshipCoreService.class);
     governmentOrganizationCrossReportService = mock(GovernmentOrganizationCrossReportService.class);
-    referralSatefyAlertsService = mock(ReferralSatefyAlertsService.class);
 
     referralService =
         new ReferralService(referralDao, nonLACountyTriggers, laCountyTrigger, triggerTablesDao,
@@ -290,8 +287,7 @@ public class R04537FirstResponseDeterminedByStaffPersonIdTest {
     screeningToReferralService = new ScreeningToReferralService(referralService, allegationService,
         crossReportService, participantService, clientRelationshipService, validator, referralDao,
         new MessageBuilder(), allegationPerpetratorHistoryService, reminders,
-        governmentOrganizationCrossReportService, clientRelationshipDao,
-        referralSatefyAlertsService);
+        governmentOrganizationCrossReportService, clientRelationshipDao);
   }
 
   /**

--- a/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R05559SetPrimaryContactStaffPersonIdTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R05559SetPrimaryContactStaffPersonIdTest.java
@@ -78,7 +78,6 @@ import gov.ca.cwds.rest.filters.TestingRequestExecutionContext;
 import gov.ca.cwds.rest.messages.MessageBuilder;
 import gov.ca.cwds.rest.services.ClientParticipants;
 import gov.ca.cwds.rest.services.ParticipantService;
-import gov.ca.cwds.rest.services.ReferralSatefyAlertsService;
 import gov.ca.cwds.rest.services.ScreeningToReferralService;
 import gov.ca.cwds.rest.services.cms.AddressService;
 import gov.ca.cwds.rest.services.cms.AllegationPerpetratorHistoryService;
@@ -168,7 +167,6 @@ public class R05559SetPrimaryContactStaffPersonIdTest {
   private CwsOfficeDao cwsOfficeDao;
   private MessageBuilder messageBuilder;
   private ClientRelationshipDao clientRelationshipDao;
-  private ReferralSatefyAlertsService referralSatefyAlertsService;
 
   private gov.ca.cwds.data.persistence.cms.Referral referral;
   private Validator validator;
@@ -265,7 +263,6 @@ public class R05559SetPrimaryContactStaffPersonIdTest {
     clientRelationshipService = mock(ClientRelationshipCoreService.class);
 
     governmentOrganizationCrossReportService = mock(GovernmentOrganizationCrossReportService.class);
-    referralSatefyAlertsService = mock(ReferralSatefyAlertsService.class);
 
     referralService =
         new ReferralService(referralDao, nonLACountyTriggers, laCountyTrigger, triggerTablesDao,
@@ -275,8 +272,7 @@ public class R05559SetPrimaryContactStaffPersonIdTest {
     screeningToReferralService = new ScreeningToReferralService(referralService, allegationService,
         crossReportService, participantService, clientRelationshipService, validator, referralDao,
         new MessageBuilder(), allegationPerpetratorHistoryService, reminders,
-        governmentOrganizationCrossReportService, clientRelationshipDao,
-        referralSatefyAlertsService);
+        governmentOrganizationCrossReportService, clientRelationshipDao);
   }
 
   /**

--- a/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R05914DoNotUpdateApprovalStatusTypeTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R05914DoNotUpdateApprovalStatusTypeTest.java
@@ -53,7 +53,6 @@ import gov.ca.cwds.rest.business.rules.UpperCaseTables;
 import gov.ca.cwds.rest.filters.TestingRequestExecutionContext;
 import gov.ca.cwds.rest.messages.MessageBuilder;
 import gov.ca.cwds.rest.services.ParticipantService;
-import gov.ca.cwds.rest.services.ReferralSatefyAlertsService;
 import gov.ca.cwds.rest.services.ScreeningToReferralService;
 import gov.ca.cwds.rest.services.cms.AddressService;
 import gov.ca.cwds.rest.services.cms.AllegationPerpetratorHistoryService;
@@ -113,7 +112,6 @@ public class R05914DoNotUpdateApprovalStatusTypeTest {
   private RIReferral riReferral;
   private RIReferralClient riReferralClient;
   private GovernmentOrganizationCrossReportService governmentOrganizationCrossReportService;
-  private ReferralSatefyAlertsService referralSatefyAlertsService;
 
   private ReferralDao referralDao;
   private ClientDao clientDao;
@@ -246,7 +244,6 @@ public class R05914DoNotUpdateApprovalStatusTypeTest {
 
     reminders = mock(Reminders.class);
     governmentOrganizationCrossReportService = mock(GovernmentOrganizationCrossReportService.class);
-    referralSatefyAlertsService = mock(ReferralSatefyAlertsService.class);
     participantService = mock(ParticipantService.class);
     clientRelationshipService = mock(ClientRelationshipCoreService.class);
 
@@ -254,7 +251,7 @@ public class R05914DoNotUpdateApprovalStatusTypeTest {
         crossReportService, participantService, clientRelationshipService,
         Validation.buildDefaultValidatorFactory().getValidator(), referralDao, new MessageBuilder(),
         allegationPerpetratorHistoryService, reminders, governmentOrganizationCrossReportService,
-        clientRelationshipDao, referralSatefyAlertsService);
+        clientRelationshipDao);
   }
 
   /**

--- a/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R07577CreateDummyDocsForReferralTest.java
+++ b/src/test/java/gov/ca/cwds/rest/business/rules/doctool/R07577CreateDummyDocsForReferralTest.java
@@ -83,7 +83,6 @@ import gov.ca.cwds.rest.filters.TestingRequestExecutionContext;
 import gov.ca.cwds.rest.messages.MessageBuilder;
 import gov.ca.cwds.rest.services.ClientParticipants;
 import gov.ca.cwds.rest.services.ParticipantService;
-import gov.ca.cwds.rest.services.ReferralSatefyAlertsService;
 import gov.ca.cwds.rest.services.ScreeningToReferralService;
 import gov.ca.cwds.rest.services.cms.AddressService;
 import gov.ca.cwds.rest.services.cms.AllegationPerpetratorHistoryService;
@@ -143,7 +142,6 @@ public class R07577CreateDummyDocsForReferralTest {
   private RIReferral riReferral;
   private RIReferralClient riReferralClient;
   private GovernmentOrganizationCrossReportService governmentOrganizationCrossReportService;
-  private ReferralSatefyAlertsService referralSatefyAlertsService;
 
   private ReferralDao referralDao;
   private ClientDao clientDao;
@@ -278,7 +276,6 @@ public class R07577CreateDummyDocsForReferralTest {
     participantService = mock(ParticipantService.class);
     clientRelationshipService = mock(ClientRelationshipCoreService.class);
     governmentOrganizationCrossReportService = mock(GovernmentOrganizationCrossReportService.class);
-    referralSatefyAlertsService = mock(ReferralSatefyAlertsService.class);
 
     referralService =
         new ReferralService(referralDao, nonLACountyTriggers, laCountyTrigger, triggerTablesDao,
@@ -289,7 +286,7 @@ public class R07577CreateDummyDocsForReferralTest {
         crossReportService, participantService, clientRelationshipService,
         Validation.buildDefaultValidatorFactory().getValidator(), referralDao, new MessageBuilder(),
         allegationPerpetratorHistoryService, reminders, governmentOrganizationCrossReportService,
-        clientRelationshipDao, referralSatefyAlertsService);
+        clientRelationshipDao);
   }
 
   /**

--- a/src/test/java/gov/ca/cwds/rest/services/ReferralSafetyAlertsServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/ReferralSafetyAlertsServiceTest.java
@@ -38,7 +38,7 @@ import gov.ca.cwds.rest.api.domain.investigation.SafetyAlerts;
  * @author CWDS API Team
  *
  */
-public class ReferralSatefyAlertsServiceTest {
+public class ReferralSafetyAlertsServiceTest {
 
   /**
    * Initialize intake code cache
@@ -49,8 +49,8 @@ public class ReferralSatefyAlertsServiceTest {
   private CountiesDao countiesDao;
   private SafetyAlertActivationReasonTypeDao safetyAlertActivationReasonTypeDao;
   private SafetyAlertService safetyAlertService;
-  private ReferralSatefyAlertsService referralSatefyAlertsService =
-      new ReferralSatefyAlertsService();
+  private ReferralSafetyAlertsService referralSafetyAlertsService =
+      new ReferralSafetyAlertsService();
 
   /**
    * 
@@ -88,13 +88,13 @@ public class ReferralSatefyAlertsServiceTest {
     safetyAlertActivationReasonType.setSystemId((short) 6401);
     when(safetyAlertActivationReasonTypeDao.findBySystemId(any(Short.class)))
         .thenReturn(new SafetyAlertActivationReasonType());
-    referralSatefyAlertsService.setReferralDao(referralDao);
-    referralSatefyAlertsService.setCountiesDao(countiesDao);
-    referralSatefyAlertsService
+    referralSafetyAlertsService.setReferralDao(referralDao);
+    referralSafetyAlertsService.setCountiesDao(countiesDao);
+    referralSafetyAlertsService
         .setSafetyAlertActivationReasonTypeDao(safetyAlertActivationReasonTypeDao);
-    referralSatefyAlertsService.setSafetyAlertService(safetyAlertService);
+    referralSafetyAlertsService.setSafetyAlertService(safetyAlertService);
     List<SafetyAlert> safetyAlert =
-        referralSatefyAlertsService.create(screeningToReferral, "071FJ86abM", clientParticipants);
+        referralSafetyAlertsService.create(screeningToReferral, "071FJ86abM", clientParticipants);
     assertThat(safetyAlert, is(notNullValue()));
     assertThat(safetyAlert.size(), is(equalTo(1)));
     assertThat(safetyAlert, containsInAnyOrder(hasProperty("fkClientId", is("098UijH1gf"))));
@@ -113,9 +113,9 @@ public class ReferralSatefyAlertsServiceTest {
     Referral referral = new ReferralEntityBuilder().setId("071FJ86abM")
         .setGovtEntityType((short) 1101).setScreenerNoteText("0I61FGt15L").build();
     when(referralDao.find(anyString())).thenReturn(referral);
-    referralSatefyAlertsService.setReferralDao(referralDao);
+    referralSafetyAlertsService.setReferralDao(referralDao);
     List<SafetyAlert> safetyAlert =
-        referralSatefyAlertsService.create(screeningToReferral, "071FJ86abM", clientParticipants);
+        referralSafetyAlertsService.create(screeningToReferral, "071FJ86abM", clientParticipants);
     assertThat(safetyAlert.size(), is(equalTo(0)));
   }
 

--- a/src/test/java/gov/ca/cwds/rest/services/ScreeningToReferralServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/ScreeningToReferralServiceTest.java
@@ -185,7 +185,6 @@ public class ScreeningToReferralServiceTest {
   private Validator validator;
   private ExternalInterfaceTables externalInterfaceTables;
   private GovernmentOrganizationCrossReportService governmentOrganizationCrossReportService;
-  private ReferralSatefyAlertsService referralSatefyAlertsService;
 
   private Participant defaultVictim;
   private Participant defaultReporter;
@@ -301,7 +300,6 @@ public class ScreeningToReferralServiceTest {
     defaultPerpetrator = new ParticipantResourceBuilder().createPerpParticipant();
 
     clientRelationshipService = mock(ClientRelationshipCoreService.class);
-    referralSatefyAlertsService = mock(ReferralSatefyAlertsService.class);
 
     messageBuilder = new MessageBuilder();
 
@@ -310,7 +308,7 @@ public class ScreeningToReferralServiceTest {
         crossReportService, participantService, clientRelationshipService,
         Validation.buildDefaultValidatorFactory().getValidator(), referralDao, messageBuilder,
         allegationPerpetratorHistoryService, reminders, governmentOrganizationCrossReportService,
-        clientRelationshipDao, referralSatefyAlertsService);
+        clientRelationshipDao);
 
   }
 
@@ -843,8 +841,8 @@ public class ScreeningToReferralServiceTest {
     String relationId = "ZXCV";
     int relationshipType = 123;
 
-    ScreeningToReferral referral = new ScreeningToReferralResourceBuilder()
-        .setRelationships(null).createScreeningToReferral();
+    ScreeningToReferral referral =
+        new ScreeningToReferralResourceBuilder().setRelationships(null).createScreeningToReferral();
 
     when(referralService.createCmsReferralFromScreening(any(), any(), any(), any()))
         .thenReturn("REFERRALID");
@@ -1281,7 +1279,7 @@ public class ScreeningToReferralServiceTest {
         crossReportService, participantService, clientRelationshipService,
         Validation.buildDefaultValidatorFactory().getValidator(), referralDao, new MessageBuilder(),
         allegationPerpetratorHistoryService, reminders, governmentOrganizationCrossReportService,
-        clientRelationshipDao, referralSatefyAlertsService);
+        clientRelationshipDao);
 
     mockParticipantService(screeningToReferral);
 

--- a/src/test/java/gov/ca/cwds/rest/services/submit/ScreeningTransformerTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/submit/ScreeningTransformerTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import gov.ca.cwds.data.cms.TestIntakeCodeCache;
 import gov.ca.cwds.data.cms.TestSystemCodeCache;
@@ -55,7 +56,6 @@ public class ScreeningTransformerTest {
   public void transformConvertsScreeningToScreeningToReferral() throws JsonProcessingException {
     Set<CrossReport> crossReports = new HashSet<>();
     Set<Allegation> allegations = new HashSet<>();
-    Set<Short> safetyAlerts = new HashSet<>();
     ScreeningToReferral expected = new ScreeningToReferralResourceBuilder()
         .setEndedAt("2017-01-03T11:10:09.999Z").setStartedAt("2017-01-02T10:09:08.999Z")
         .setIncidentDate("2017-01-01").setLegacySourceTable("REFERL_T").setLimitedAccessDate(null)
@@ -64,7 +64,7 @@ public class ScreeningTransformerTest {
         .setAdditionalInformation("additional information")
         .setScreeningDecision("Screening Decision").setCurrentLocationOfChildren(null)
         .setParticipants(null).setCrossReports(crossReports).setAddress(null)
-        .setAllegations(allegations).setSafetyAlerts(safetyAlerts).setSafetyAlertInformationn(null)
+        .setAllegations(allegations).setSafetyAlerts(null).setSafetyAlertInformationn(null)
         .createScreeningToReferral();
     ScreeningToReferral actual = new ScreeningTransformer().transform(screening, "0X5", "34");
 
@@ -75,7 +75,6 @@ public class ScreeningTransformerTest {
   public void transformConvertsScreeningToScreeningToReferralWhenCommunicationMethodNull() {
     Set<CrossReport> crossReports = new HashSet<>();
     Set<Allegation> allegations = new HashSet<>();
-    Set<Short> safetyAlerts = new HashSet<>();
     ScreeningToReferral expected = new ScreeningToReferralResourceBuilder()
         .setEndedAt("2017-01-03T11:10:09.999Z").setStartedAt("2017-01-02T10:09:08.999Z")
         .setIncidentDate("2017-01-01").setLegacySourceTable("REFERL_T").setLimitedAccessDate(null)
@@ -84,7 +83,7 @@ public class ScreeningTransformerTest {
         .setAdditionalInformation("additional information")
         .setScreeningDecision("Screening Decision").setCurrentLocationOfChildren(null)
         .setParticipants(null).setCrossReports(crossReports).setAddress(null)
-        .setAllegations(allegations).setSafetyAlerts(safetyAlerts).setSafetyAlertInformationn(null)
+        .setAllegations(allegations).setSafetyAlerts(null).setSafetyAlertInformationn(null)
         .createScreeningToReferral();
     Screening screening = new ScreeningResourceBuilder().setCommunicationMethod("").build();
     ScreeningToReferral actual = new ScreeningTransformer().transform(screening, "0X5", "34");
@@ -96,7 +95,6 @@ public class ScreeningTransformerTest {
   public void transformConvertsScreeningToScreeningToReferralWhenScreeningDecisionDetailBlank() {
     Set<CrossReport> crossReports = new HashSet<>();
     Set<Allegation> allegations = new HashSet<>();
-    Set<Short> safetyAlerts = new HashSet<>();
     ScreeningToReferral expected = new ScreeningToReferralResourceBuilder()
         .setEndedAt("2017-01-03T11:10:09.999Z").setStartedAt("2017-01-02T10:09:08.999Z")
         .setIncidentDate("2017-01-01").setLegacySourceTable("REFERL_T").setLimitedAccessDate(null)
@@ -105,7 +103,7 @@ public class ScreeningTransformerTest {
         .setAdditionalInformation("additional information")
         .setScreeningDecision("Screening Decision").setScreeningDecisionDetail("")
         .setCurrentLocationOfChildren(null).setParticipants(null).setCrossReports(crossReports)
-        .setAddress(null).setAllegations(allegations).setSafetyAlerts(safetyAlerts)
+        .setAddress(null).setAllegations(allegations).setSafetyAlerts(null)
         .setSafetyAlertInformationn(null).createScreeningToReferral();
     Screening screening = new ScreeningResourceBuilder().setScreeningDecisionDetail("").build();
     ScreeningToReferral actual = new ScreeningTransformer().transform(screening, "0X5", "34");
@@ -114,7 +112,8 @@ public class ScreeningTransformerTest {
   }
 
   @Test
-  public void transformConvertsScreeningToScreeningToReferralWhenIncidentAddressProvided() {
+  public void transformConvertsScreeningToScreeningToReferralWhenIncidentAddressProvided()
+      throws JsonProcessingException {
     LegacyDescriptor legacyDescriptor = new LegacyDescriptorEntityBuilder().build();
     AddressIntakeApi nsAddress = new AddressIntakeApiResourceBuilder().setType("Day Care")
         .setLegacyDescriptor(legacyDescriptor).build();
@@ -124,7 +123,6 @@ public class ScreeningTransformerTest {
 
     Set<CrossReport> crossReports = new HashSet<>();
     Set<Allegation> allegations = new HashSet<>();
-    Set<Short> safetyAlerts = new HashSet<>();
     ScreeningToReferral expected = new ScreeningToReferralResourceBuilder()
         .setEndedAt("2017-01-03T11:10:09.999Z").setStartedAt("2017-01-02T10:09:08.999Z")
         .setIncidentDate("2017-01-01").setLegacySourceTable("REFERL_T").setLimitedAccessDate(null)
@@ -133,11 +131,13 @@ public class ScreeningTransformerTest {
         .setAdditionalInformation("additional information")
         .setScreeningDecision("Screening Decision").setCurrentLocationOfChildren(null)
         .setParticipants(null).setCrossReports(crossReports).setAddress(address)
-        .setAllegations(allegations).setSafetyAlerts(safetyAlerts).setSafetyAlertInformationn(null)
+        .setAllegations(allegations).setSafetyAlerts(null).setSafetyAlertInformationn(null)
         .createScreeningToReferral();
     Screening screening = new ScreeningResourceBuilder().setIncidentAddress(nsAddress).build();
     ScreeningToReferral actual = new ScreeningTransformer().transform(screening, "0X5", "34");
-
+    ObjectMapper mapper = new ObjectMapper();
+    String a = mapper.writeValueAsString(actual);
+    String e = mapper.writeValueAsString(expected);
     assertEquals(actual, expected);
   }
 

--- a/src/test/java/gov/ca/cwds/rest/services/submit/ScreeningTransformerTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/submit/ScreeningTransformerTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import gov.ca.cwds.data.cms.TestIntakeCodeCache;
 import gov.ca.cwds.data.cms.TestSystemCodeCache;
@@ -112,8 +111,7 @@ public class ScreeningTransformerTest {
   }
 
   @Test
-  public void transformConvertsScreeningToScreeningToReferralWhenIncidentAddressProvided()
-      throws JsonProcessingException {
+  public void transformConvertsScreeningToScreeningToReferralWhenIncidentAddressProvided() {
     LegacyDescriptor legacyDescriptor = new LegacyDescriptorEntityBuilder().build();
     AddressIntakeApi nsAddress = new AddressIntakeApiResourceBuilder().setType("Day Care")
         .setLegacyDescriptor(legacyDescriptor).build();
@@ -135,9 +133,6 @@ public class ScreeningTransformerTest {
         .createScreeningToReferral();
     Screening screening = new ScreeningResourceBuilder().setIncidentAddress(nsAddress).build();
     ScreeningToReferral actual = new ScreeningTransformer().transform(screening, "0X5", "34");
-    ObjectMapper mapper = new ObjectMapper();
-    String a = mapper.writeValueAsString(actual);
-    String e = mapper.writeValueAsString(expected);
     assertEquals(actual, expected);
   }
 


### PR DESCRIPTION
## Description
As per the discussion with PO safety alerts on the screening should be added to "Additional Safety Information" and saved to legacy on screener alert. Made the changes accordingly by removing the link to create a safety Alert table in legacy for the client and fixed the test cases.

## Jira Issue link
https://osi-cwds.atlassian.net/browse/HOT-2056

## Tests
- [x] I have included unit tests 
- [ ] I have included functional tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the google code style of this project.
- [x] I have ran all tests for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
