### PR TITLE
Zip code error Source: addresses[0].zip Fix

### DIFF
--- a/src/main/java/gov/ca/cwds/rest/api/domain/AddressIntakeApi.java
+++ b/src/main/java/gov/ca/cwds/rest/api/domain/AddressIntakeApi.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import gov.ca.cwds.rest.api.Request;
 import gov.ca.cwds.rest.api.Response;
+import gov.ca.cwds.rest.validation.ValidZipCode;
 import io.dropwizard.jackson.JsonSnakeCase;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -61,7 +62,7 @@ public class AddressIntakeApi extends DomainObject implements Request, Response 
 
   @JsonProperty("zip")
   @ApiModelProperty(value = "Zip", example = "95835")
-  @Size(min = 5, max = 5)
+  @ValidZipCode
   private String zip;
 
   @JsonProperty("legacy_descriptor")
@@ -89,12 +90,8 @@ public class AddressIntakeApi extends DomainObject implements Request, Response 
    * @param legacyDescriptor - legacyDescriptor
    */
   @SuppressWarnings("squid:S00107")
-  public AddressIntakeApi(String legacySourceTable,
-      String addressId,
-      String streetAddress,  String city,
-      String state, String zip,
-      String type,
-      LegacyDescriptor legacyDescriptor) {
+  public AddressIntakeApi(String legacySourceTable, String addressId, String streetAddress,
+      String city, String state, String zip, String type, LegacyDescriptor legacyDescriptor) {
     super();
     this.legacySourceTable = legacySourceTable;
     this.legacyId = addressId;


### PR DESCRIPTION
Zip code is not validating the value "0" added an annotation to fix the below issue.

com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'addresses': was expecting ('true', 'false' or 'null')
 at [Source: addresses[0].zip size must be between 5 and 5; line: 1, column: 10]
	at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:1702)
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:558)
	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._reportInvalidToken(ReaderBasedJsonParser.java:2839)
	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser._handleOddValue(ReaderBasedJsonParser.java:1903)
	at com.fasterxml.jackson.core.json.ReaderBasedJsonParser.nextToken(ReaderBasedJsonParser.java:749)
	at com.fasterxml.jackson.databind.ObjectMapper._initForReading(ObjectMapper.java:3834)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:3783)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2842)
	at gov.ca.cwds.utils.JsonUtils.from(JsonUtils.java:24)
	at gov.ca.cwds.rest.exception.mapper.CustomJerseyViolationExceptionMapper.unmarshallData(CustomJerseyViolationExceptionMapper.java:83)
	at gov.ca.cwds.rest.exception.mapper.CustomJerseyViolationExceptionMapper.toResponse(CustomJerseyViolationExceptionMapper.java:49)
	at gov.ca.cwds.rest.exception.mapper.CustomJerseyViolationExceptionMapper.toResponse(CustomJerseyViolationExceptionMapper.java:30)
	at org.glassfish.jersey.server.ServerRuntime$Responder.mapException(ServerRuntime.java:601)
	at org.glassfish.jersey.server.ServerRuntime$Responder.process(ServerRuntime.java:476)
	at org.glassfish.jersey.server.ServerRuntime$2.run(ServerRuntime.java:334)


