### PR TITLE
Hot 2147 ssb reports do not display ssb fields

### DIFF
--- a/src/main/java/gov/ca/cwds/rest/services/mapper/SafelySurrenderedBabiesMapper.java
+++ b/src/main/java/gov/ca/cwds/rest/services/mapper/SafelySurrenderedBabiesMapper.java
@@ -2,7 +2,9 @@ package gov.ca.cwds.rest.services.mapper;
 
 import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValueCheckStrategy;
 import org.mapstruct.factory.Mappers;
 
 import gov.ca.cwds.data.persistence.ns.SafelySurrenderedBabiesEntity;
@@ -13,12 +15,24 @@ import gov.ca.cwds.rest.api.domain.SafelySurenderedBabiesIntakeApi;
 public interface SafelySurrenderedBabiesMapper {
   SafelySurrenderedBabiesMapper INSTANCE = Mappers.getMapper(SafelySurrenderedBabiesMapper.class);
 
+  @Mapping(target = "parentGuardGivenBraceletId",
+      expression = "java(safelySurrenderedBabiesEntity.getParentGuardGivenBraceletId() == \"U\"? null : safelySurrenderedBabiesEntity.getParentGuardGivenBraceletId())")
+  @Mapping(target = "parentGuardProvMedQuestion",
+      expression = "java(safelySurrenderedBabiesEntity.getParentGuardProvMedQuestion() == \"U\"? null : safelySurrenderedBabiesEntity.getParentGuardProvMedQuestion())")
+  @Mapping(target = "relationToChild",
+      expression = "java(safelySurrenderedBabiesEntity.getRelationToChild() == \"\"? null : safelySurrenderedBabiesEntity.getRelationToChild())")
   SafelySurenderedBabiesIntakeApi map(SafelySurrenderedBabiesEntity safelySurrenderedBabiesEntity);
 
   @InheritInverseConfiguration
+  @Mapping(target = "parentGuardGivenBraceletId", defaultValue = "U")
+  @Mapping(target = "parentGuardProvMedQuestion", defaultValue = "U")
+  @Mapping(target = "relationToChild", defaultValue = "")
   SafelySurrenderedBabiesEntity map(SafelySurenderedBabiesIntakeApi safelySurrenderedBabies);
 
   @InheritInverseConfiguration
+  @Mapping(target = "parentGuardGivenBraceletId", defaultValue = "U")
+  @Mapping(target = "parentGuardProvMedQuestion", defaultValue = "U")
+  @Mapping(target = "relationToChild", defaultValue = "")
   SafelySurrenderedBabiesEntity map(SafelySurenderedBabiesIntakeApi safelySurrenderedBabies,
       @MappingTarget SafelySurrenderedBabiesEntity safelySurrenderedBabiesEntity);
 

--- a/src/test/java/gov/ca/cwds/rest/resources/ParticipantIntakeApiResourceIRT.java
+++ b/src/test/java/gov/ca/cwds/rest/resources/ParticipantIntakeApiResourceIRT.java
@@ -6,6 +6,7 @@ import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
+import gov.ca.cwds.rest.api.domain.SafelySurenderedBabiesIntakeApi;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -41,6 +42,40 @@ public class ParticipantIntakeApiResourceIRT extends IntakeBaseTest {
         objectMapper.readValue(actualJson.getBytes(), ParticipantIntakeApi.class);
     String expectedResponse =
         fixture("fixtures/gov/ca/cwds/rest/resources/participant-intake-api-post-response.json");
+    expectedResponse = populateGeneratedIdentifiers(expectedResponse, participant);
+    JSONAssert.assertEquals(expectedResponse, actualJson, JSONCompareMode.NON_EXTENSIBLE);
+  }
+
+  @Test
+  public void testPostWithDefaultsInSsb() throws Exception {
+    ParticipantIntakeApi participantRequest = objectMapper.readValue(
+        fixture("fixtures/gov/ca/cwds/rest/resources/participant-intake-api-post-request.json").
+            getBytes(), ParticipantIntakeApi.class);
+    SafelySurenderedBabiesIntakeApi ssb = new SafelySurenderedBabiesIntakeApi();
+    ssb.setSurrenderedBy("Unknown");
+    participantRequest.setSafelySurenderedBabies(ssb);
+
+    String actualJson = getStringResponse(
+        doPostCall(RESOURCE_SCREENINGS + "/36/" + RESOURCE_PARTICIPANTS,
+            objectMapper.writeValueAsString(participantRequest)));
+
+    ParticipantIntakeApi participant =
+        objectMapper.readValue(actualJson.getBytes(), ParticipantIntakeApi.class);
+    String expectedResponse =
+        fixture("fixtures/gov/ca/cwds/rest/resources/participant-intake-api-post-response.json");
+    expectedResponse = populateGeneratedIdentifiers(expectedResponse, participant);
+
+    expectedResponse = expectedResponse.replaceAll("\\\"relation_to_child.*", "");
+    expectedResponse = expectedResponse.replaceAll("\\\"bracelet_id.*", "");
+    expectedResponse = expectedResponse.replaceAll("\\\"parent_guardian_given_bracelet_id.*", "");
+    expectedResponse = expectedResponse.replaceAll("\\\"parent_guardian_provided_med_questionaire.*", "");
+    expectedResponse = expectedResponse.replaceAll("\\\"med_questionaire_return_date.*", "");
+    expectedResponse = expectedResponse.replaceAll("\\\"comments.*", "");
+
+    JSONAssert.assertEquals(expectedResponse, actualJson, JSONCompareMode.NON_EXTENSIBLE);
+  }
+
+  private String populateGeneratedIdentifiers(String expectedResponse, ParticipantIntakeApi participant) {
     expectedResponse = expectedResponse.replace("${participant_id}", participant.getId());
     expectedResponse =
         expectedResponse.replace("${address_id_1}", participant.getAddresses().stream()
@@ -62,7 +97,7 @@ public class ParticipantIntakeApiResourceIRT extends IntakeBaseTest {
         participant.getCsecs().stream()
             .filter(csec -> "Victim Before Foster Care".equals(csec.getCsecCodeId())).findFirst()
             .orElse(null).getId());
-    JSONAssert.assertEquals(expectedResponse, actualJson, JSONCompareMode.NON_EXTENSIBLE);
+    return expectedResponse;
   }
 
   @Test


### PR DESCRIPTION
## Description
Postgres SSB table has restrictions. Given PR will convert empty SSB values to default entity values to match table restrictions. It will also convert table default values to empty response values. It looks like table structure might be reworked as we should not have validation on Postgres side, we should allow any values to be saved.

## Jira Issue link
https://osi-cwds.atlassian.net/browse/HOT-2147

## Tests
- [ ] I have included unit tests 
- [ ] I have included functional tests 
- [x] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] My code follows the google code style of this project.
- [ ] I have ran all tests for the project.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
