### PR TITLE
correct domain validation of SpecialProjectReferral

### DIFF
--- a/src/main/java/gov/ca/cwds/rest/api/domain/cms/SpecialProjectReferral.java
+++ b/src/main/java/gov/ca/cwds/rest/api/domain/cms/SpecialProjectReferral.java
@@ -24,7 +24,6 @@ public class SpecialProjectReferral extends ReportingDomain implements Request, 
   
   private static final long serialVersionUID = 1L;
 
-  @NotNull
   @Size(max = CMS_ID_LEN)
   @ApiModelProperty(required = true, readOnly = true, value = "", example = "1234ABC123")
   private String id;

--- a/src/test/java/gov/ca/cwds/rest/services/cms/SpecialProjectReferralServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/cms/SpecialProjectReferralServiceTest.java
@@ -140,6 +140,7 @@ public class SpecialProjectReferralServiceTest {
         .saveCsecSpecialProjectReferral(csecs, referralId, incidentCounty, messageBuilder);
     assertThat(sprPosted.getClass(),
         is(gov.ca.cwds.rest.api.domain.cms.SpecialProjectReferral.class));
+    assertThat(messageBuilder.getMessages().size(), is(0));
   }
 
   @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Correct domain validation of SpecialProjectReferral

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
SpecialProjectReferral domain was requiring the the 'id' field to be not null.  This was causing the domain validation to fail when a SpecialProjectReferral was created.  The id is assigned/generated when the entity is created.

## Jira Issue link
<!--- Provide the link to Jira -->

## Tests
- [X] I have included unit tests 
- [ ] I have included functional tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [X] My code follows the google code style of this project.
- [X] I have ran all tests for the project.
- [X] My code is in a stable state ready to be deployable, but not necessarily complete.
- [X] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
