### PR TITLE
HOT-2465 Initialize "related_screening_id" field 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,9 @@ sourceCompatibility = 1.8
 applicationDefaultJvmArgs = ["-Djava.library.path=.:./lib:/var/lib/jenkins/workspace/API/lib:/usr/local/lib"]
 
 project.ext {
-    coreApiVersion = '1.7.5_855-RC' 
+    coreApiVersion = '1.7.5_855-RC'
     apiVersion = '0.9.1'
-    cwdsModelVersion = '0.8.4_655-RC'
+    cwdsModelVersion = '0.8.4_661-RC'
     configPath = '$rootProject.projectDir/config/'
     dropwizardVersion = '1.1.0'
     dropwizardFlywayVersion = '1.0.0-1'
@@ -168,7 +168,7 @@ dependencies {
 	}
 	compile group: 'gov.ca.cwds.api', name: 'drools-engine', version: coreApiVersion
     compile group: 'gov.ca.cwds.api', name: 'legacy-data-access-services', version: coreApiVersion
-    
+
 	// LOGGING:
 	compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4jVersion
   	compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: log4jVersion

--- a/src/main/java/gov/ca/cwds/data/ns/ParticipantDao.java
+++ b/src/main/java/gov/ca/cwds/data/ns/ParticipantDao.java
@@ -2,6 +2,7 @@ package gov.ca.cwds.data.ns;
 
 import static gov.ca.cwds.data.persistence.ns.ParticipantEntity.FIND_BY_SCREENING_ID_AND_LEGACY_ID;
 import static gov.ca.cwds.data.persistence.ns.ParticipantEntity.FIND_PARTICIPANTS_BY_SCREENING_IDS;
+import static gov.ca.cwds.data.persistence.ns.ParticipantEntity.FIND_PARTICIPANT_BY_RELATED_SCREENING_ID_AND_LEGACY_ID;
 import static gov.ca.cwds.data.persistence.xa.CaresQueryAccelerator.readOnlyQuery;
 
 import java.util.ArrayList;
@@ -46,8 +47,7 @@ public class ParticipantDao extends BaseDaoImpl<ParticipantEntity> {
    * @return Set of Legacy Id-s
    */
   public Set<String> findLegacyIdListByScreeningId(String screeningId) {
-    @SuppressWarnings("unchecked")
-    final Query<String> query =
+    @SuppressWarnings("unchecked") final Query<String> query =
         grabSession().getNamedQuery(ParticipantEntity.FIND_LEGACY_ID_LIST_BY_SCREENING_ID)
             .setParameter(PathParam.SCREENING_ID, screeningId);
     readOnlyQuery(query);
@@ -57,14 +57,13 @@ public class ParticipantDao extends BaseDaoImpl<ParticipantEntity> {
   /**
    * @param screeningIds Set of Screening ID-s
    * @return map where key is a Screening ID and value is a Set of Participant Entities bound to the
-   *         screening
+   * screening
    */
   public Map<String, Set<ParticipantEntity>> findByScreeningIds(Set<String> screeningIds) {
     if (screeningIds == null || screeningIds.isEmpty()) {
       return new HashMap<>();
     }
-    @SuppressWarnings("unchecked")
-    final Query<ParticipantEntity> query =
+    @SuppressWarnings("unchecked") final Query<ParticipantEntity> query =
         grabSession().getNamedQuery(FIND_PARTICIPANTS_BY_SCREENING_IDS).setParameter("screeningIds",
             screeningIds);
     readOnlyQuery(query);
@@ -81,8 +80,7 @@ public class ParticipantDao extends BaseDaoImpl<ParticipantEntity> {
   }
 
   public List<ParticipantEntity> getByScreeningId(String screeningId) {
-    @SuppressWarnings("unchecked")
-    final Query<ParticipantEntity> query =
+    @SuppressWarnings("unchecked") final Query<ParticipantEntity> query =
         grabSession().getNamedQuery(constructNamedQueryName("findByScreeningId"))
             .setParameter(PathParam.SCREENING_ID, screeningId);
     readOnlyQuery(query);
@@ -103,8 +101,7 @@ public class ParticipantDao extends BaseDaoImpl<ParticipantEntity> {
 
   public ParticipantEntity findByScreeningIdAndParticipantId(String screeningId,
       String participantId) {
-    @SuppressWarnings("unchecked")
-    final Query<ParticipantEntity> query = this.grabSession()
+    @SuppressWarnings("unchecked") final Query<ParticipantEntity> query = this.grabSession()
         .getNamedQuery(constructNamedQueryName("findByScreeningIdAndParticipantId"))
         .setParameter(PathParam.SCREENING_ID, screeningId)
         .setParameter(PathParam.PARTICIPANT_ID, participantId);
@@ -113,11 +110,27 @@ public class ParticipantDao extends BaseDaoImpl<ParticipantEntity> {
   }
 
   public ParticipantEntity findByScreeningIdAndLegacyId(String screeningId, String legacyId) {
-    @SuppressWarnings("unchecked")
-    final Query<ParticipantEntity> query =
+    @SuppressWarnings("unchecked") final Query<ParticipantEntity> query =
         this.grabSession().getNamedQuery(FIND_BY_SCREENING_ID_AND_LEGACY_ID)
             .setParameter(PathParam.SCREENING_ID, screeningId)
             .setParameter(PathParam.LEGACY_ID, legacyId);
+    readOnlyQuery(query);
+    return query.uniqueResult();
+  }
+
+  /**
+   * @param screeningId screening id
+   * @param legacyId client legacy identifier
+   * @return Participant that has been create in scope of screening (related_screening_id) but has
+   * not been attached
+   */
+  public ParticipantEntity findByRelatedScreeningIdAndLegacyId(String screeningId,
+      String legacyId) {
+    @SuppressWarnings("unchecked") final Query<ParticipantEntity> query = this.grabSession()
+        .getNamedQuery(
+            constructNamedQueryName(FIND_PARTICIPANT_BY_RELATED_SCREENING_ID_AND_LEGACY_ID))
+        .setParameter(PathParam.RELATED_SCREENING_ID, screeningId)
+        .setParameter(PathParam.LEGACY_ID, legacyId);
     readOnlyQuery(query);
     return query.uniqueResult();
   }

--- a/src/main/java/gov/ca/cwds/data/persistence/ns/ParticipantEntity.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/ns/ParticipantEntity.java
@@ -265,6 +265,7 @@ public class ParticipantEntity
     probationYouth = participantIntakeApi.isProbationYouth();
     approximateAge = participantIntakeApi.getApproximateAge();
     approximateAgeUnits = participantIntakeApi.getApproximateAgeUnits();
+    relatedScreeningId = participantIntakeApi.getRelatedScreeningId();
     return this;
   }
 

--- a/src/main/java/gov/ca/cwds/data/persistence/ns/ParticipantEntity.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/ns/ParticipantEntity.java
@@ -4,6 +4,7 @@ import static gov.ca.cwds.data.persistence.ns.ParticipantEntity.FIND_BY_SCREENIN
 import static gov.ca.cwds.data.persistence.ns.ParticipantEntity.FIND_LEGACY_ID_LIST_BY_SCREENING_ID;
 import static gov.ca.cwds.data.persistence.ns.ParticipantEntity.FIND_PARTICIPANTS_BY_PARTICIPANT_IDS;
 import static gov.ca.cwds.data.persistence.ns.ParticipantEntity.FIND_PARTICIPANTS_BY_SCREENING_IDS;
+import static gov.ca.cwds.data.persistence.ns.ParticipantEntity.FIND_PARTICIPANT_BY_RELATED_SCREENING_ID_AND_LEGACY_ID;
 import static gov.ca.cwds.rest.util.FerbDateUtils.freshDate;
 
 import java.io.Serializable;
@@ -60,6 +61,8 @@ import gov.ca.cwds.rest.api.domain.ParticipantIntakeApi;
     query = "FROM ParticipantEntity WHERE screeningId = :screeningId AND legacyId = :legacyId")
 @NamedQuery(name = FIND_PARTICIPANTS_BY_PARTICIPANT_IDS,
     query = "FROM ParticipantEntity WHERE id IN :participantIds")
+@NamedQuery(name = FIND_PARTICIPANT_BY_RELATED_SCREENING_ID_AND_LEGACY_ID,
+    query = "FROM ParticipantEntity WHERE relatedScreeningId = :relatedScreeningId AND legacyId = :legacyId AND screeningId is null")
 @Entity
 @Table(name = "participants")
 @SuppressWarnings({"squid:S00107"})
@@ -76,6 +79,8 @@ public class ParticipantEntity
       "gov.ca.cwds.data.persistence.ns.ParticipantEntity.findByScreeningIdAndLegacyId";
   public static final String FIND_PARTICIPANTS_BY_PARTICIPANT_IDS =
       "gov.ca.cwds.data.persistence.ns.ParticipantEntity.findByParticipantsId";
+  public static final String FIND_PARTICIPANT_BY_RELATED_SCREENING_ID_AND_LEGACY_ID =
+      "gov.ca.cwds.data.persistence.ns.ParticipantEntity.findParticipantByRelatedScreeningIdAndLegacyId";
 
   @Id
   @Column(name = "id")
@@ -156,6 +161,9 @@ public class ParticipantEntity
 
   @Column(name = "approximate_age_units")
   private String approximateAgeUnits;
+
+  @Column(name = "related_screening_id")
+  private String relatedScreeningId;
 
   @OneToMany(cascade = CascadeType.ALL)
   @JoinColumn(name = "participant_id", insertable = false, updatable = false)
@@ -413,6 +421,14 @@ public class ParticipantEntity
 
   public void setSafelySurrenderedBabies(SafelySurrenderedBabiesEntity safelySurrenderedBabies) {
     this.safelySurrenderedBabies = safelySurrenderedBabies;
+  }
+
+  public String getRelatedScreeningId() {
+    return relatedScreeningId;
+  }
+
+  public void setRelatedScreeningId(String relatedScreeningId) {
+    this.relatedScreeningId = relatedScreeningId;
   }
 
   public void setRoles(String[] roles) {

--- a/src/main/java/gov/ca/cwds/rest/api/domain/ParticipantIntakeApi.java
+++ b/src/main/java/gov/ca/cwds/rest/api/domain/ParticipantIntakeApi.java
@@ -167,6 +167,9 @@ public class ParticipantIntakeApi extends ReportingDomain implements Request, Re
   @JsonProperty("safely_surrendered_babies")
   private SafelySurrenderedBabiesIntakeApi safelySurenderedBabies;
 
+  @JsonIgnoreProperties
+  private String relatedScreeningId;
+
   /**
    * empty constructor
    */
@@ -605,6 +608,14 @@ public class ParticipantIntakeApi extends ReportingDomain implements Request, Re
 
   public void setSafelySurenderedBabies(SafelySurrenderedBabiesIntakeApi safelySurenderedBabies) {
     this.safelySurenderedBabies = safelySurenderedBabies;
+  }
+
+  public String getRelatedScreeningId() {
+    return relatedScreeningId;
+  }
+
+  public void setRelatedScreeningId(String relatedScreeningId) {
+    this.relatedScreeningId = relatedScreeningId;
   }
 
   /**

--- a/src/main/java/gov/ca/cwds/rest/core/Api.java
+++ b/src/main/java/gov/ca/cwds/rest/core/Api.java
@@ -48,6 +48,7 @@ public final class Api {
     public static final String PARTICIPANT_IDS = "participantIds";
     public static final String PARTICIPANT_ID = "participantId";
     public static final String LEGACY_ID = "legacyId";
+    public static final String RELATED_SCREENING_ID = "relatedScreeningId";
 
 
     private PathParam() {}

--- a/src/main/java/gov/ca/cwds/rest/services/relationship/RelationshipFacadeLegacyAndNewDB.java
+++ b/src/main/java/gov/ca/cwds/rest/services/relationship/RelationshipFacadeLegacyAndNewDB.java
@@ -439,7 +439,7 @@ public class RelationshipFacadeLegacyAndNewDB implements RelationshipFacade {
         if (client == null) {
           continue;
         }
-        participantEntity1 = createParticipant(client);
+        participantEntity1 = createParticipant(client, screeningId);
       } else {
         participantEntity1 = participantDao
             .findByScreeningIdAndLegacyId(screeningId, clientRelationship.getPrimaryClientId());
@@ -450,7 +450,7 @@ public class RelationshipFacadeLegacyAndNewDB implements RelationshipFacade {
         if (client == null) {
           continue;
         }
-        participantEntity2 = createParticipant(client);
+        participantEntity2 = createParticipant(client, screeningId);
       } else {
         participantEntity2 = participantDao
             .findByScreeningIdAndLegacyId(screeningId, clientRelationship.getSecondaryClientId());
@@ -479,8 +479,9 @@ public class RelationshipFacadeLegacyAndNewDB implements RelationshipFacade {
     return result;
   }
 
-  private ParticipantEntity createParticipant(Client client) {
+  private ParticipantEntity createParticipant(Client client, String screeningId) {
     ParticipantIntakeApi participantIntakeApi = clientTransformer.tranform(client);
+    participantIntakeApi.setRelatedScreeningId(screeningId);
     participantIntakeApi = participantIntakeApiService.create(participantIntakeApi);
     participantDao.getSessionFactory().getCurrentSession().flush();
     return participantDao.find(participantIntakeApi.getId());

--- a/src/test/java/gov/ca/cwds/data/persistence/ns/ParticipantEntityTest.java
+++ b/src/test/java/gov/ca/cwds/data/persistence/ns/ParticipantEntityTest.java
@@ -41,6 +41,7 @@ public class ParticipantEntityTest extends Doofenshmirtz<ParticipantEntity> {
   private Boolean probationYouth = false;
   private String approximateAge = "24";
   private String approximateAgeUnits = "YR";
+  private String relatedScreeningId = "123123";
   private ScreeningEntity screeningEntity;
   ParticipantEntity target;
 
@@ -62,6 +63,7 @@ public class ParticipantEntityTest extends Doofenshmirtz<ParticipantEntity> {
     ParticipantEntity pe = new ParticipantEntity(id, birthDate, deathDate, firstName, gender,
         lastName, ssn, screeningEntity, legacyId, roles, languages, middleName, nameSuffix, races,
         ethnicity, legacySourceTable, sensitivity, sealed, probationYouth, approximateAge, approximateAgeUnits);
+    pe.setRelatedScreeningId(relatedScreeningId);
     assertThat(pe.getId(), is(equalTo(id)));
     assertThat(pe.getPrimaryKey(), is(equalTo(id)));
     assertThat(pe.getDateOfBirth(), is(equalTo(birthDate)));
@@ -84,6 +86,7 @@ public class ParticipantEntityTest extends Doofenshmirtz<ParticipantEntity> {
     assertThat(pe.getProbationYouth(), is(equalTo(probationYouth)));
     assertThat(pe.getApproximateAge(), is(equalTo(approximateAge)));
     assertThat(pe.getApproximateAgeUnits(), is(equalTo(approximateAgeUnits)));
+    assertThat(pe.getRelatedScreeningId(), is(equalTo(relatedScreeningId)));
   }
 
   @Test
@@ -442,6 +445,13 @@ public class ParticipantEntityTest extends Doofenshmirtz<ParticipantEntity> {
   public void setId_A$String() throws Exception {
     String id = null;
     target.setId(id);
+  }
+
+  @Test
+  public void getRelateScreeningId_A$() throws Exception {
+    String actual = target.getRelatedScreeningId();
+    String expected = null;
+    assertThat(actual, is(equalTo(expected)));
   }
 
 }

--- a/src/test/resources/liquibase/api/api_intake_ns_database_master.xml
+++ b/src/test/resources/liquibase/api/api_intake_ns_database_master.xml
@@ -36,6 +36,7 @@
   <include file="liquibase/data/201806251352_alter_participants_add_column_date_of_death.sql"/>
   <include file="liquibase/data/201807021637_add_probation_youth.xml"/>
   <include file="liquibase/data/201807021050_add_additional_fields_to_relationship.xml"/>
+  <include file="liquibase/data/201809071248_add_related_screening_field_to_participant.xml"/>
 
   <include file="data/screening_data.xml" relativeToChangelogFile="true"/>
   <include file="data/addresses_data.xml" relativeToChangelogFile="true"/>


### PR DESCRIPTION

## Description
When creating new participant with screening_id null - related_screening_id field should be initialized

## Jira Issue link
https://osi-cwds.atlassian.net/browse/HOT-2465

## Tests
- [x] I have included unit tests 
- [ ] I have included functional tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] My code follows the google code style of this project.
- [ ] I have ran all tests for the project.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.