### PR TITLE
HOT-2508 Merge participant creation into one implementation, first cut

### DIFF
--- a/src/main/java/gov/ca/cwds/rest/services/screening/participant/AddressIntakeApiService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/screening/participant/AddressIntakeApiService.java
@@ -1,4 +1,4 @@
-package gov.ca.cwds.rest.services;
+package gov.ca.cwds.rest.services.screening.participant;
 
 import org.apache.commons.lang3.NotImplementedException;
 
@@ -10,6 +10,7 @@ import gov.ca.cwds.data.ns.LegacyDescriptorDao;
 import gov.ca.cwds.data.persistence.ns.LegacyDescriptorEntity;
 import gov.ca.cwds.rest.api.domain.AddressIntakeApi;
 import gov.ca.cwds.rest.api.domain.LegacyDescriptor;
+import gov.ca.cwds.rest.services.TypedCrudsService;
 
 /**
  * Business layer object to work on {@link AddressIntakeApi}
@@ -95,8 +96,7 @@ public class AddressIntakeApiService
     throw new NotImplementedException("Update is not implemented");
   }
 
-  public LegacyDescriptor saveLegacyDescriptor(LegacyDescriptor legacyDescriptor,
-      String describableId) {
+  LegacyDescriptor saveLegacyDescriptor(LegacyDescriptor legacyDescriptor, String describableId) {
     if (legacyDescriptor == null || describableId == null) {
       return null;
     }

--- a/src/main/java/gov/ca/cwds/rest/services/screening/participant/ParticipantIntakeApiService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/screening/participant/ParticipantIntakeApiService.java
@@ -43,7 +43,6 @@ import gov.ca.cwds.rest.api.domain.ParticipantIntakeApi;
 import gov.ca.cwds.rest.api.domain.PhoneNumber;
 import gov.ca.cwds.rest.api.domain.SafelySurrenderedBabiesIntakeApi;
 import gov.ca.cwds.rest.resources.parameter.ParticipantResourceParameters;
-import gov.ca.cwds.rest.services.AddressIntakeApiService;
 import gov.ca.cwds.rest.services.ServiceException;
 import gov.ca.cwds.rest.services.TypedCrudsService;
 import gov.ca.cwds.rest.services.mapper.CsecMapper;

--- a/src/test/java/gov/ca/cwds/rest/services/screening/participant/AddressIntakeApiServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/screening/participant/AddressIntakeApiServiceTest.java
@@ -1,4 +1,4 @@
-package gov.ca.cwds.rest.services;
+package gov.ca.cwds.rest.services.screening.participant;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/gov/ca/cwds/rest/services/screening/participant/ParticipantIntakeApiServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/screening/participant/ParticipantIntakeApiServiceTest.java
@@ -47,7 +47,6 @@ import gov.ca.cwds.rest.api.domain.LegacyDescriptor;
 import gov.ca.cwds.rest.api.domain.ParticipantIntakeApi;
 import gov.ca.cwds.rest.api.domain.PhoneNumber;
 import gov.ca.cwds.rest.resources.parameter.ParticipantResourceParameters;
-import gov.ca.cwds.rest.services.AddressIntakeApiService;
 import gov.ca.cwds.rest.services.ServiceException;
 import gov.ca.cwds.rest.services.junit.template.ServiceTestTemplate;
 import gov.ca.cwds.rest.services.mapper.CsecMapper;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
Merge participant creation into one implementation
There is no call from Intake to
POST `/screenings/#{screening_id}/participants`
However, there is a call to POST `/screenings/#{screening_id}/participant`
In this story we will remove `/screenings/#{screening_id}/participant`
and move over the functionality to POST `/screenings/#{screening_id}/participants`
Ferb is internally calling the related service for `/screenings/#{screening_id}/participants`
so we will keep that functionality as well in a different method than create

## Jira Issue link
<!--- Provide the link to Jira -->
[Merge participant creation into one implementation](https://osi-cwds.atlassian.net/browse/HOT-2508)

## Tests
- [x] I have included unit tests 
- [ ] I have included functional tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the google code style of this project.
- [x] I have ran all tests for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
