### PR TITLE
HOT-2508 Merge participant creation into one implementation, first cut

### DIFF
--- a/src/main/java/gov/ca/cwds/inject/ResourcesModule.java
+++ b/src/main/java/gov/ca/cwds/inject/ResourcesModule.java
@@ -82,7 +82,7 @@ import gov.ca.cwds.rest.resources.investigation.PeopleResource;
 import gov.ca.cwds.rest.resources.investigation.RelationshipListResource;
 import gov.ca.cwds.rest.resources.investigation.SafetyAlertsResource;
 import gov.ca.cwds.rest.resources.parameter.ParticipantResourceParameters;
-import gov.ca.cwds.rest.resources.screening.participant.ParticipantIntakeApiResource;
+import gov.ca.cwds.rest.resources.screening.participant.ParticipantResource;
 import gov.ca.cwds.rest.resources.screeningparticipant.ScreeningParticipantResource;
 import gov.ca.cwds.rest.resources.submit.ScreeningSubmitResource;
 import gov.ca.cwds.rest.services.AddressService;
@@ -125,7 +125,7 @@ import gov.ca.cwds.rest.services.investigation.InvestigationService;
 import gov.ca.cwds.rest.services.investigation.PeopleService;
 import gov.ca.cwds.rest.services.investigation.SafetyAlertsService;
 import gov.ca.cwds.rest.services.investigation.contact.ContactService;
-import gov.ca.cwds.rest.services.screening.participant.ParticipantIntakeApiService;
+import gov.ca.cwds.rest.services.screening.participant.ParticipantService;
 import gov.ca.cwds.rest.services.screeningparticipant.ScreeningParticipantService;
 import gov.ca.cwds.rest.services.submit.ScreeningSubmitService;
 
@@ -152,7 +152,7 @@ public class ResourcesModule extends AbstractModule {
     bind(ApplicationResource.class);
     bind(SwaggerResource.class);
     bind(AddressResource.class);
-    bind(ParticipantIntakeApiResource.class);
+    bind(ParticipantResource.class);
     bind(PersonResource.class);
     bind(ScreeningResource.class);
     bind(ScreeningSubmitResource.class);
@@ -404,7 +404,7 @@ public class ResourcesModule extends AbstractModule {
   public TypedResourceDelegate<ParticipantResourceParameters, ParticipantIntakeApi> participantServiceBackedResource(
       Injector injector) {
     return new TypedServiceBackedResourceDelegate<>(
-        injector.getInstance(ParticipantIntakeApiService.class));
+        injector.getInstance(ParticipantService.class));
   }
 
   @Provides

--- a/src/main/java/gov/ca/cwds/rest/resources/screening/participant/ParticipantResource.java
+++ b/src/main/java/gov/ca/cwds/rest/resources/screening/participant/ParticipantResource.java
@@ -27,7 +27,7 @@ import gov.ca.cwds.rest.api.domain.ParticipantIntakeApi;
 import gov.ca.cwds.rest.core.Api.ResponseMessage;
 import gov.ca.cwds.rest.resources.TypedResourceDelegate;
 import gov.ca.cwds.rest.resources.parameter.ParticipantResourceParameters;
-import gov.ca.cwds.rest.services.screening.participant.ParticipantIntakeApiService;
+import gov.ca.cwds.rest.services.screening.participant.ParticipantService;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -37,7 +37,7 @@ import io.swagger.annotations.ApiResponses;
 
 /**
  * A resource providing a RESTful interface for {@link ParticipantIntakeApi}. It delegates functions
- * to {@link ParticipantIntakeApiService}.
+ * to {@link ParticipantService}.
  *
  * @author CWDS API Team
  */
@@ -46,7 +46,7 @@ import io.swagger.annotations.ApiResponses;
 @Path(value = RESOURCE_SCREENINGS + "/{" + SCREENING_ID + "}/" + RESOURCE_PARTICIPANTS)
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class ParticipantIntakeApiResource {
+public class ParticipantResource {
 
   @Inject
   @ParticipantServiceBackedResource
@@ -55,7 +55,7 @@ public class ParticipantIntakeApiResource {
   /**
    * Constructor
    */
-  public ParticipantIntakeApiResource() {
+  public ParticipantResource() {
     // no ops
   }
 

--- a/src/main/java/gov/ca/cwds/rest/services/ScreeningService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/ScreeningService.java
@@ -1,6 +1,5 @@
 package gov.ca.cwds.rest.services;
 
-import gov.ca.cwds.rest.api.domain.cms.AgencyType;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
@@ -10,7 +9,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import java.util.stream.Stream;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.NotImplementedException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
@@ -49,6 +47,7 @@ import gov.ca.cwds.rest.api.domain.ParticipantIntakeApi;
 import gov.ca.cwds.rest.api.domain.Screening;
 import gov.ca.cwds.rest.api.domain.ScreeningDashboard;
 import gov.ca.cwds.rest.api.domain.ScreeningDashboardList;
+import gov.ca.cwds.rest.api.domain.cms.AgencyType;
 import gov.ca.cwds.rest.api.domain.enums.ScreeningStatus;
 import gov.ca.cwds.rest.filters.RequestExecutionContext;
 import gov.ca.cwds.rest.resources.parameter.ParticipantResourceParameters;
@@ -57,7 +56,7 @@ import gov.ca.cwds.rest.services.mapper.AgencyMapper;
 import gov.ca.cwds.rest.services.mapper.AllegationMapper;
 import gov.ca.cwds.rest.services.mapper.CrossReportMapper;
 import gov.ca.cwds.rest.services.mapper.ScreeningMapper;
-import gov.ca.cwds.rest.services.screening.participant.ParticipantIntakeApiService;
+import gov.ca.cwds.rest.services.screening.participant.ParticipantService;
 
 /**
  * Business layer object to work on {@link Screening}.
@@ -91,7 +90,7 @@ public class ScreeningService implements CrudsService {
   private ScreeningDao screeningDao;
 
   @Inject
-  private ParticipantIntakeApiService participantIntakeApiService;
+  private ParticipantService participantService;
 
   @Inject
   private ScreeningMapper screeningMapper;
@@ -265,10 +264,10 @@ public class ScreeningService implements CrudsService {
     }
 
     final List<ParticipantEntity> participantEntities =
-        participantIntakeApiService.getByScreeningId(screeningId);
+        participantService.getByScreeningId(screeningId);
 
     for (ParticipantEntity participantEntity : participantEntities) {
-      final ParticipantIntakeApi participantIntakeApi = participantIntakeApiService
+      final ParticipantIntakeApi participantIntakeApi = participantService
           .find(new ParticipantResourceParameters(id, participantEntity.getId()));
       screening.getParticipantIntakeApis().add(participantIntakeApi);
     }
@@ -279,18 +278,14 @@ public class ScreeningService implements CrudsService {
   List<GovernmentAgencyEntity> filterLastUpdatedByCategory(
       List<GovernmentAgencyEntity> agencyEntities) {
 
-    String[] agencyTypes = {
-        AgencyType.DISTRICT_ATTORNEY.name(),
-        AgencyType.LAW_ENFORCEMENT.name(),
-        AgencyType.COMMUNITY_CARE_LICENSING.name(),
-        AgencyType.COUNTY_LICENSING.name(),
-    };
+    String[] agencyTypes = {AgencyType.DISTRICT_ATTORNEY.name(), AgencyType.LAW_ENFORCEMENT.name(),
+        AgencyType.COMMUNITY_CARE_LICENSING.name(), AgencyType.COUNTY_LICENSING.name(),};
 
     List<GovernmentAgencyEntity> filteredAgencyEntities = new ArrayList<>();
     for (String agencyType : agencyTypes) {
-      CollectionUtils.addIgnoreNull(filteredAgencyEntities, agencyEntities.stream()
-          .filter(a -> agencyType.equals(a.getCategory()))
-          .max((a1, a2) -> a1.getUpdatedAt().compareTo(a2.getUpdatedAt())).orElse(null));
+      CollectionUtils.addIgnoreNull(filteredAgencyEntities,
+          agencyEntities.stream().filter(a -> agencyType.equals(a.getCategory()))
+              .max((a1, a2) -> a1.getUpdatedAt().compareTo(a2.getUpdatedAt())).orElse(null));
     }
     return filteredAgencyEntities;
   }
@@ -463,7 +458,7 @@ public class ScreeningService implements CrudsService {
   private void createUpdateDeleteParticipants(Screening screening) {
     final Set<ParticipantIntakeApi> participantIntakeApis = new HashSet<>();
     final Set<String> participantIdsOld =
-        participantIntakeApiService.getByScreeningId(screening.getId()).stream()
+        participantService.getByScreeningId(screening.getId()).stream()
             .map(ParticipantEntity::getId).collect(Collectors.toSet());
 
     for (ParticipantIntakeApi participantIntakeApi : screening.getParticipantIntakeApis()) {
@@ -471,10 +466,10 @@ public class ScreeningService implements CrudsService {
       if (participantIntakeApiId == null) {
         participantIntakeApi.setScreeningId(screening.getId());
         final ParticipantIntakeApi createdParticipantIntakeApi =
-            participantIntakeApiService.persistParticipantObjectInNS(participantIntakeApi);
+            participantService.persistParticipantObjectInNS(participantIntakeApi);
         participantIntakeApis.add(createdParticipantIntakeApi);
       } else {
-        final ParticipantIntakeApi updatedParticipantIntakeApi = participantIntakeApiService.update(
+        final ParticipantIntakeApi updatedParticipantIntakeApi = participantService.update(
             new ParticipantResourceParameters(screening.getId(), participantIntakeApiId),
             participantIntakeApi);
         participantIntakeApis.add(updatedParticipantIntakeApi);
@@ -483,7 +478,7 @@ public class ScreeningService implements CrudsService {
     }
 
     // Delete old ones that are not in the new.
-    participantIdsOld.forEach(participantId -> participantIntakeApiService
+    participantIdsOld.forEach(participantId -> participantService
         .delete(new ParticipantResourceParameters(screening.getId(), participantId)));
 
     screening.setParticipantIntakeApis(participantIntakeApis);
@@ -537,13 +532,12 @@ public class ScreeningService implements CrudsService {
     this.crossReportDao = crossReportDao;
   }
 
-  public ParticipantIntakeApiService getParticipantIntakeApiService() {
-    return participantIntakeApiService;
+  public ParticipantService getParticipantService() {
+    return participantService;
   }
 
-  public void setParticipantIntakeApiService(
-      ParticipantIntakeApiService participantIntakeApiService) {
-    this.participantIntakeApiService = participantIntakeApiService;
+  public void setParticipantService(ParticipantService participantService) {
+    this.participantService = participantService;
   }
 
   public ScreeningMapper getScreeningMapper() {

--- a/src/main/java/gov/ca/cwds/rest/services/relationship/RelationshipFacadeLegacyAndNewDB.java
+++ b/src/main/java/gov/ca/cwds/rest/services/relationship/RelationshipFacadeLegacyAndNewDB.java
@@ -44,7 +44,7 @@ import gov.ca.cwds.rest.api.domain.cms.SystemCodeCache;
 import gov.ca.cwds.rest.filters.RequestExecutionContext;
 import gov.ca.cwds.rest.services.ScreeningRelationshipService;
 import gov.ca.cwds.rest.services.mapper.RelationshipMapper;
-import gov.ca.cwds.rest.services.screening.participant.ParticipantIntakeApiService;
+import gov.ca.cwds.rest.services.screening.participant.ParticipantService;
 import gov.ca.cwds.rest.services.screeningparticipant.ClientTransformer;
 
 /**
@@ -72,7 +72,7 @@ public class RelationshipFacadeLegacyAndNewDB implements RelationshipFacade {
 
   private final ScreeningRelationshipService screeningRelationshipService;
   private final LegacyDescriptorDao legacyDescriptorDao;
-  private final ParticipantIntakeApiService participantIntakeApiService;
+  private final ParticipantService participantService;
   private final ClientTransformer clientTransformer;
 
   @Inject
@@ -80,7 +80,7 @@ public class RelationshipFacadeLegacyAndNewDB implements RelationshipFacade {
       ClientRelationshipDao cmsRelationshipDao, RelationshipDao nsRelationshipDao,
       ClientDao cmsClientDao, ScreeningRelationshipService screeningRelationshipService,
       LegacyDescriptorDao legacyDescriptorDao,
-      ParticipantIntakeApiService participantIntakeApiService,
+      ParticipantService participantService,
       ClientTransformer clientTransformer) {
     this.participantDao = participantDao;
     this.cmsRelationshipDao = cmsRelationshipDao;
@@ -89,7 +89,7 @@ public class RelationshipFacadeLegacyAndNewDB implements RelationshipFacade {
 
     this.screeningRelationshipService = screeningRelationshipService;
     this.legacyDescriptorDao = legacyDescriptorDao;
-    this.participantIntakeApiService = participantIntakeApiService;
+    this.participantService = participantService;
     this.clientTransformer = clientTransformer;
     initSystemCodes();
   }
@@ -484,7 +484,7 @@ public class RelationshipFacadeLegacyAndNewDB implements RelationshipFacade {
   private ParticipantEntity createParticipant(Client client, String screeningId) {
     ParticipantIntakeApi participantIntakeApi = clientTransformer.tranform(client);
     participantIntakeApi.setRelatedScreeningId(screeningId);
-    participantIntakeApi = participantIntakeApiService.create(participantIntakeApi);
+    participantIntakeApi = participantService.create(participantIntakeApi);
     participantDao.getSessionFactory().getCurrentSession().flush();
     return participantDao.find(participantIntakeApi.getId());
   }

--- a/src/main/java/gov/ca/cwds/rest/services/screening/participant/AddressService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/screening/participant/AddressService.java
@@ -17,7 +17,7 @@ import gov.ca.cwds.rest.services.TypedCrudsService;
  *
  * @author CWDS API team
  */
-public class AddressIntakeApiService
+public class AddressService
     implements TypedCrudsService<String, AddressIntakeApi, AddressIntakeApi> {
 
   private AddressesDao addressesDao;
@@ -31,7 +31,7 @@ public class AddressIntakeApiService
    * @param legacyDescriptorDao - {@link Dao} for {@link LegacyDescriptorDao}
    */
   @Inject
-  public AddressIntakeApiService(AddressesDao addressesDao,
+  public AddressService(AddressesDao addressesDao,
       LegacyDescriptorDao legacyDescriptorDao) {
     this.addressesDao = addressesDao;
     this.legacyDescriptorDao = legacyDescriptorDao;

--- a/src/main/java/gov/ca/cwds/rest/services/screening/participant/ParticipantService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/screening/participant/ParticipantService.java
@@ -53,10 +53,10 @@ import gov.ca.cwds.rest.services.mapper.SafelySurrenderedBabiesMapper;
  *
  * @author CWDS API Team
  */
-public class ParticipantIntakeApiService implements
+public class ParticipantService implements
     TypedCrudsService<ParticipantResourceParameters, ParticipantIntakeApi, ParticipantIntakeApi> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ParticipantIntakeApiService.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ParticipantService.class);
 
   @Inject
   private ParticipantDao participantDao;
@@ -74,7 +74,7 @@ public class ParticipantIntakeApiService implements
   private ParticipantAddressesDao participantAddressesDao;
 
   @Inject
-  private AddressIntakeApiService addressIntakeApiService;
+  private AddressService addressService;
 
   @Inject
   private PhoneNumbersDao phoneNumbersDao;
@@ -463,7 +463,7 @@ public class ParticipantIntakeApiService implements
       addressesEntityManaged = addressesDao.create(new Addresses(addressIntakeApi));
       LegacyDescriptor legacyDescriptor = addressIntakeApi.getLegacyDescriptor();
       addressIntakeApi = new AddressIntakeApi(addressesEntityManaged);
-      addressIntakeApi.setLegacyDescriptor(addressIntakeApiService
+      addressIntakeApi.setLegacyDescriptor(addressService
           .saveLegacyDescriptor(legacyDescriptor, addressesEntityManaged.getId()));
     }
     return new AddressesWrapper(addressIntakeApi, addressesEntityManaged);

--- a/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/ScreeningParticipantService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/screeningparticipant/ScreeningParticipantService.java
@@ -1,6 +1,13 @@
 package gov.ca.cwds.rest.services.screeningparticipant;
 
+import javax.persistence.EntityNotFoundException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.inject.Inject;
+
 import gov.ca.cwds.data.CrudsDao;
 import gov.ca.cwds.data.cms.ClientDao;
 import gov.ca.cwds.data.ns.ScreeningDao;
@@ -11,12 +18,8 @@ import gov.ca.cwds.rest.api.domain.ParticipantIntakeApi;
 import gov.ca.cwds.rest.api.domain.enums.ScreeningStatus;
 import gov.ca.cwds.rest.services.ServiceException;
 import gov.ca.cwds.rest.services.TypedCrudsService;
-import gov.ca.cwds.rest.services.screening.participant.ParticipantIntakeApiService;
+import gov.ca.cwds.rest.services.screening.participant.ParticipantService;
 import io.dropwizard.hibernate.UnitOfWork;
-import javax.persistence.EntityNotFoundException;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Business layer object to work on ParticipantIntakeApi
@@ -32,7 +35,7 @@ public class ScreeningParticipantService
   private ScreeningDao screeningDao;
 
   @Inject
-  private ParticipantIntakeApiService participantIntakeApiService;
+  private ParticipantService participantService;
 
   @Inject
   private ParticipantDaoFactoryImpl participantDaoFactory;
@@ -61,9 +64,9 @@ public class ScreeningParticipantService
           createParticipant(legacyDescriptor.getId(), legacyDescriptor.getTableName());
       participantIntakeApi.setScreeningId(incomingParticipantIntakeApi.getScreeningId());
       participantIntakeApi.setProbationYouth(isProbationYouth(legacyDescriptor.getId()));
-      return participantIntakeApiService.persistParticipantObjectInNS(participantIntakeApi);
+      return participantService.persistParticipantObjectInNS(participantIntakeApi);
     } else {
-      return participantIntakeApiService.persistParticipantObjectInNS(incomingParticipantIntakeApi);
+      return participantService.persistParticipantObjectInNS(incomingParticipantIntakeApi);
     }
   }
 
@@ -120,9 +123,8 @@ public class ScreeningParticipantService
   /**
    * @param participantIntakeApiService - participantIntakeApiService
    */
-  public void setParticipantIntakeApiService(
-      ParticipantIntakeApiService participantIntakeApiService) {
-    this.participantIntakeApiService = participantIntakeApiService;
+  public void setParticipantIntakeApiService(ParticipantService participantIntakeApiService) {
+    this.participantService = participantIntakeApiService;
   }
 
   /**

--- a/src/test/java/gov/ca/cwds/inject/ResourcesModuleTest.java
+++ b/src/test/java/gov/ca/cwds/inject/ResourcesModuleTest.java
@@ -43,7 +43,7 @@ import gov.ca.cwds.rest.services.investigation.CrossReportListService;
 import gov.ca.cwds.rest.services.investigation.HistoryOfInvolvementService;
 import gov.ca.cwds.rest.services.investigation.InvestigationService;
 import gov.ca.cwds.rest.services.investigation.SafetyAlertsService;
-import gov.ca.cwds.rest.services.screening.participant.ParticipantIntakeApiService;
+import gov.ca.cwds.rest.services.screening.participant.ParticipantService;
 
 public class ResourcesModuleTest {
   ResourcesModule resourceModule;
@@ -191,7 +191,7 @@ public class ResourcesModuleTest {
   @Test
   public void participantServiceBackedResourceShouldRetrieveServiceFromInjector() {
     resourceModule.participantServiceBackedResource(injector);
-    verify(injector).getInstance(ParticipantIntakeApiService.class);
+    verify(injector).getInstance(ParticipantService.class);
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/rest/services/ScreeningServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/ScreeningServiceTest.java
@@ -5,15 +5,11 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-
-import gov.ca.cwds.data.persistence.ns.GovernmentAgencyEntity;
-import gov.ca.cwds.rest.api.domain.cms.AgencyType;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
@@ -25,7 +21,6 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.rest.RestStatus;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,6 +34,7 @@ import gov.ca.cwds.data.ns.CrossReportDao;
 import gov.ca.cwds.data.ns.ScreeningAddressDao;
 import gov.ca.cwds.data.ns.ScreeningDao;
 import gov.ca.cwds.data.persistence.ns.CrossReportEntity;
+import gov.ca.cwds.data.persistence.ns.GovernmentAgencyEntity;
 import gov.ca.cwds.data.persistence.ns.ScreeningEntity;
 import gov.ca.cwds.data.persistence.ns.ScreeningWrapper;
 import gov.ca.cwds.fixture.ScreeningWrapperEntityBuilder;
@@ -48,11 +44,12 @@ import gov.ca.cwds.rest.api.Response;
 import gov.ca.cwds.rest.api.domain.Screening;
 import gov.ca.cwds.rest.api.domain.ScreeningDashboard;
 import gov.ca.cwds.rest.api.domain.ScreeningDashboardList;
+import gov.ca.cwds.rest.api.domain.cms.AgencyType;
 import gov.ca.cwds.rest.filters.TestingRequestExecutionContext;
 import gov.ca.cwds.rest.services.mapper.AllegationMapper;
 import gov.ca.cwds.rest.services.mapper.CrossReportMapper;
 import gov.ca.cwds.rest.services.mapper.ScreeningMapper;
-import gov.ca.cwds.rest.services.screening.participant.ParticipantIntakeApiService;
+import gov.ca.cwds.rest.services.screening.participant.ParticipantService;
 import gov.ca.cwds.rest.util.Doofenshmirtz;
 
 public class ScreeningServiceTest extends Doofenshmirtz<ScreeningEntity> {
@@ -98,7 +95,7 @@ public class ScreeningServiceTest extends Doofenshmirtz<ScreeningEntity> {
   private ScreeningAddressDao screeningAddressDao;
 
   @Mock
-  private ParticipantIntakeApiService participantIntakeApiService;
+  private ParticipantService participantService;
 
   @Override
   @Before
@@ -134,7 +131,7 @@ public class ScreeningServiceTest extends Doofenshmirtz<ScreeningEntity> {
     target.setCrossReportDao(crossReportDao);
     target.setCrossReportMapper(crossReportMapper);
     target.setScreeningAddressDao(screeningAddressDao);
-    target.setParticipantIntakeApiService(participantIntakeApiService);
+    target.setParticipantService(participantService);
 
     new TestingRequestExecutionContext("0X5");
   }

--- a/src/test/java/gov/ca/cwds/rest/services/screening/participant/AddressServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/screening/participant/AddressServiceTest.java
@@ -27,9 +27,9 @@ import gov.ca.cwds.rest.api.domain.LegacyDescriptor;
  * @author CWDS API Team
  *
  */
-public class AddressIntakeApiServiceTest {
+public class AddressServiceTest {
 
-  private AddressIntakeApiService addressIntakeApiService;
+  private AddressService addressIntakeApiService;
   private AddressesDao addressesDao;
   private LegacyDescriptorDao legacyDescriptorDao;
 
@@ -40,7 +40,7 @@ public class AddressIntakeApiServiceTest {
   public void setup() throws Exception {
     addressesDao = mock(AddressesDao.class);
     legacyDescriptorDao = mock(LegacyDescriptorDao.class);
-    addressIntakeApiService = new AddressIntakeApiService(addressesDao, legacyDescriptorDao);
+    addressIntakeApiService = new AddressService(addressesDao, legacyDescriptorDao);
   }
 
   /**

--- a/src/test/java/gov/ca/cwds/rest/services/screening/participant/ParticipantServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/screening/participant/ParticipantServiceTest.java
@@ -54,7 +54,7 @@ import gov.ca.cwds.rest.services.mapper.SafelySurrenderedBabiesMapper;
 
 /**
  */
-public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
+public class ParticipantServiceTest implements ServiceTestTemplate {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -72,7 +72,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
   @Mock
   private ParticipantAddressesDao participantAddressesDao;
   @Mock
-  private AddressIntakeApiService addressIntakeApiService;
+  private AddressService addressService;
   @Mock
   private PhoneNumbersDao phoneNumbersDao;
   @Mock
@@ -89,14 +89,14 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
   LegacyDescriptor legacyDescriptor;
 
   @InjectMocks
-  private ParticipantIntakeApiService participantIntakeApiService =
-      new ParticipantIntakeApiService();
+  private ParticipantService participantService =
+      new ParticipantService();
 
   @Before
   @Override
   public void setup() throws Exception {
-    participantIntakeApiService.setCsecMapper(CsecMapper.INSTANCE);
-    participantIntakeApiService
+    participantService.setCsecMapper(CsecMapper.INSTANCE);
+    participantService
         .setSafelySurrenderedBabiesMapper(SafelySurrenderedBabiesMapper.INSTANCE);
 
     MAPPER.configure(SerializationFeature.INDENT_OUTPUT, true);
@@ -140,7 +140,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
   @Test
   public void testFindThrowsAssertionError() throws Exception {
     try {
-      participantIntakeApiService.find(null);
+      participantService.find(null);
       fail();
     } catch (ServiceException e) {
       assertEquals("NULL argument for FIND participant", e.getMessage());
@@ -149,7 +149,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
     ParticipantResourceParameters nullScreeningIdParameters =
         new ParticipantResourceParameters(null, "-1");
     try {
-      participantIntakeApiService.find(nullScreeningIdParameters);
+      participantService.find(nullScreeningIdParameters);
       fail();
     } catch (ServiceException e) {
       assertEquals("NULL screening/participant id for FIND participant", e.getMessage());
@@ -158,7 +158,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
     ParticipantResourceParameters nullParticipantIdParameters =
         new ParticipantResourceParameters("-1", null);
     try {
-      participantIntakeApiService.find(nullParticipantIdParameters);
+      participantService.find(nullParticipantIdParameters);
       fail();
     } catch (ServiceException e) {
       assertEquals("NULL screening/participant id for FIND participant", e.getMessage());
@@ -204,7 +204,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
     expected.setSafelySurenderedBabies(null);
 
     ParticipantIntakeApi found =
-        participantIntakeApiService.find(new ParticipantResourceParameters("-1", participantId));
+        participantService.find(new ParticipantResourceParameters("-1", participantId));
     assertThat(found, is(expected));
 
   }
@@ -214,7 +214,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
   public void testFindReturnsNullWhenNotFound() throws Exception {
     when(participantDao.findByScreeningIdAndParticipantId("-1", "000")).thenReturn(null);
     ParticipantIntakeApi found =
-        participantIntakeApiService.find(new ParticipantResourceParameters("-1", "000"));
+        participantService.find(new ParticipantResourceParameters("-1", "000"));
 
     assertThat(found, is(nullValue()));
 
@@ -229,7 +229,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
   @Test
   public void testCreateThrowsAssertionError() throws Exception {
     try {
-      participantIntakeApiService.create(null);
+      participantService.create(null);
       fail();
     } catch (ServiceException e) {
       assertEquals("NULL argument for CREATE participant", e.getMessage());
@@ -263,7 +263,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
     expected.addPhoneNumbers(new HashSet<>(Arrays.asList(phoneNumber1, phoneNumber2)));
     expected00.addPhoneNumbers(new HashSet<>(Arrays.asList(phoneNumber11, phoneNumber22)));
 
-    ParticipantIntakeApi found = participantIntakeApiService.create(expected);
+    ParticipantIntakeApi found = participantService.create(expected);
     assertThat(found, is(expected00));
   }
 
@@ -271,7 +271,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
   public void shouldContainALegacyDescriptorWhenCreated() {
     ParticipantIntakeApi expected = new ParticipantIntakeApi(participantEntity);
     expected.setLegacyDescriptor(legacyDescriptor);
-    ParticipantIntakeApi found = participantIntakeApiService.persistParticipantObjectInNS(expected);
+    ParticipantIntakeApi found = participantService.persistParticipantObjectInNS(expected);
     LegacyDescriptor legacyDescriptor = found.getLegacyDescriptor();
     assertEquals(legacyDescriptor.getId(), found.getLegacyDescriptor().getId());
     assertEquals(legacyDescriptor.getUiId(), found.getLegacyDescriptor().getUiId());
@@ -299,7 +299,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
   @Test
   public void testDeleteThrowsAssertionError() throws Exception {
     try {
-      participantIntakeApiService.delete(null);
+      participantService.delete(null);
       fail();
     } catch (ServiceException e) {
       assertEquals("NULL argument for DELETE participant", e.getMessage());
@@ -308,7 +308,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
     ParticipantResourceParameters nullScreeningIdParameters =
         new ParticipantResourceParameters(null, "-1");
     try {
-      participantIntakeApiService.delete(nullScreeningIdParameters);
+      participantService.delete(nullScreeningIdParameters);
       fail();
     } catch (ServiceException e) {
       assertEquals("NULL screening/participant id for DELETE participant", e.getMessage());
@@ -317,7 +317,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
     ParticipantResourceParameters nullParticipantIdParameters =
         new ParticipantResourceParameters("-1", null);
     try {
-      participantIntakeApiService.delete(nullParticipantIdParameters);
+      participantService.delete(nullParticipantIdParameters);
       fail();
     } catch (ServiceException e) {
       assertEquals("NULL screening/participant id for DELETE participant", e.getMessage());
@@ -326,7 +326,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
 
   @Test
   public void testDeleteNullParticipant() {
-    participantIntakeApiService.delete(new ParticipantResourceParameters("1", "2"));
+    participantService.delete(new ParticipantResourceParameters("1", "2"));
   }
 
   @Override
@@ -386,7 +386,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
     ParticipantIntakeApi expected = new ParticipantIntakeApi(participantEntity);
 
     ParticipantIntakeApi found =
-        participantIntakeApiService.delete(new ParticipantResourceParameters("-1", participantId));
+        participantService.delete(new ParticipantResourceParameters("-1", participantId));
 
     assertThat(found, is(expected));
   }
@@ -395,14 +395,14 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
   @Test
   public void testUpdateThrowsAssertionError() throws Exception {
     try {
-      participantIntakeApiService.update(null, new ParticipantIntakeApi());
+      participantService.update(null, new ParticipantIntakeApi());
       fail();
     } catch (Exception e) {
       assertEquals("NULL argument for UPDATE participant", e.getMessage());
     }
 
     try {
-      participantIntakeApiService.update(new ParticipantResourceParameters(null, null), null);
+      participantService.update(new ParticipantResourceParameters(null, null), null);
       fail();
     } catch (Exception e) {
       assertEquals("NULL argument for UPDATE participant", e.getMessage());
@@ -411,7 +411,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
     ParticipantResourceParameters nullScreeningIdParameters =
         new ParticipantResourceParameters(null, "-1");
     try {
-      participantIntakeApiService.update(nullScreeningIdParameters, new ParticipantIntakeApi());
+      participantService.update(nullScreeningIdParameters, new ParticipantIntakeApi());
       fail();
     } catch (ServiceException e) {
       assertEquals("NULL screening/participant id for UPDATE participant", e.getMessage());
@@ -420,7 +420,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
     ParticipantResourceParameters nullParticipantIdParameters =
         new ParticipantResourceParameters("-1", null);
     try {
-      participantIntakeApiService.update(nullParticipantIdParameters, new ParticipantIntakeApi());
+      participantService.update(nullParticipantIdParameters, new ParticipantIntakeApi());
       fail();
     } catch (ServiceException e) {
       assertEquals("NULL screening/participant id for UPDATE participant", e.getMessage());
@@ -517,7 +517,7 @@ public class ParticipantIntakeApiServiceTest implements ServiceTestTemplate {
     expected00.setScreeningId("-1");
 
     ParticipantIntakeApi found =
-        participantIntakeApiService.update(new ParticipantResourceParameters("-1", pId), expected);
+        participantService.update(new ParticipantResourceParameters("-1", pId), expected);
     assertThat(found, is(expected00));
 
   }

--- a/src/test/java/gov/ca/cwds/rest/services/screeningparticipant/ScreeningParticipantServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/screeningparticipant/ScreeningParticipantServiceTest.java
@@ -33,7 +33,7 @@ import gov.ca.cwds.rest.api.domain.ParticipantIntakeApi;
 import gov.ca.cwds.rest.api.domain.cms.LegacyTable;
 import gov.ca.cwds.rest.api.domain.enums.ScreeningStatus;
 import gov.ca.cwds.rest.services.ServiceException;
-import gov.ca.cwds.rest.services.screening.participant.ParticipantIntakeApiService;
+import gov.ca.cwds.rest.services.screening.participant.ParticipantService;
 
 /**
  * @author CWDS API Team
@@ -49,14 +49,14 @@ public class ScreeningParticipantServiceTest {
       new ScreeningParticipantService();
   private ScreeningDao screeningDao;
   private ClientDao clientDao;
-  private ParticipantIntakeApiService participantIntakeApiService;
+  private ParticipantService participantService;
   private ParticipantDaoFactoryImpl participantDaoFactory;
   private ParticipantMapperFactoryImpl participantMapperFactoryImpl;
 
   @Before
   public void setup() {
     screeningDao = mock(ScreeningDao.class);
-    participantIntakeApiService = mock(ParticipantIntakeApiService.class);
+    participantService = mock(ParticipantService.class);
     participantDaoFactory = mock(ParticipantDaoFactoryImpl.class);
     participantMapperFactoryImpl = mock(ParticipantMapperFactoryImpl.class);
     clientDao = mock(ClientDao.class);
@@ -65,7 +65,7 @@ public class ScreeningParticipantServiceTest {
     screeningParticipantService.setClientDao(clientDao);
     screeningParticipantService.setParticipantDaoFactory(participantDaoFactory);
     screeningParticipantService.setParticipantMapperFactoryImpl(participantMapperFactoryImpl);
-    screeningParticipantService.setParticipantIntakeApiService(participantIntakeApiService);
+    screeningParticipantService.setParticipantIntakeApiService(participantService);
   }
 
   /**
@@ -129,7 +129,7 @@ public class ScreeningParticipantServiceTest {
     when(clientDao.findProbationYouth(any(String.class))).thenReturn(probationYouthClient);
     when(participantDaoFactory.create(any(String.class))).thenReturn(crudsDaoObject);
     // Return same object as passed to the method
-    when(participantIntakeApiService.persistParticipantObjectInNS(any()))
+    when(participantService.persistParticipantObjectInNS(any()))
         .then(AdditionalAnswers.returnsFirstArg());
     ParticipantIntakeApi expected = screeningParticipantService.create(participantIntakeApi);
     assertThat(expected, is(notNullValue()));
@@ -144,7 +144,7 @@ public class ScreeningParticipantServiceTest {
     ParticipantIntakeApi participantIntakeApi = new ParticipantIntakeApiResourceBuilder()
         .setScreeningId("18").setLegacyDescriptor(null).build();
     when(screeningDao.find(any(String.class))).thenReturn(new ScreeningEntity());
-    when(participantIntakeApiService.persistParticipantObjectInNS(any()))
+    when(participantService.persistParticipantObjectInNS(any()))
         .thenReturn(participantIntakeApi);
     ParticipantIntakeApi expected = screeningParticipantService.create(participantIntakeApi);
     assertThat(expected, is(notNullValue()));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
Merge participant creation into one implementation
There is no call from Intake to
POST `/screenings/#{screening_id}/participants`
However, there is a call to POST `/screenings/#{screening_id}/participant`
In this story we will remove `/screenings/#{screening_id}/participant`
and move over the functionality to POST `/screenings/#{screening_id}/participants`
Ferb is internally calling the related service for `/screenings/#{screening_id}/participants`
so we will keep that functionality as well in a different method than create

## Jira Issue link
<!--- Provide the link to Jira -->
[Merge participant creation into one implementation](https://osi-cwds.atlassian.net/browse/HOT-2508)

## Tests
- [x] I have included unit tests 
- [ ] I have included functional tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the google code style of this project.
- [x] I have ran all tests for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
