### PR TITLE
merge fix

### DIFF
--- a/src/main/java/gov/ca/cwds/rest/services/relationship/RelationshipFacadeLegacyAndNewDB.java
+++ b/src/main/java/gov/ca/cwds/rest/services/relationship/RelationshipFacadeLegacyAndNewDB.java
@@ -79,8 +79,7 @@ public class RelationshipFacadeLegacyAndNewDB implements RelationshipFacade {
   public RelationshipFacadeLegacyAndNewDB(ParticipantDao participantDao,
       ClientRelationshipDao cmsRelationshipDao, RelationshipDao nsRelationshipDao,
       ClientDao cmsClientDao, ScreeningRelationshipService screeningRelationshipService,
-      LegacyDescriptorDao legacyDescriptorDao,
-      ParticipantService participantService,
+      LegacyDescriptorDao legacyDescriptorDao, ParticipantService participantService,
       ClientTransformer clientTransformer) {
     this.participantDao = participantDao;
     this.cmsRelationshipDao = cmsRelationshipDao;
@@ -484,7 +483,7 @@ public class RelationshipFacadeLegacyAndNewDB implements RelationshipFacade {
   private ParticipantEntity createParticipant(Client client, String screeningId) {
     ParticipantIntakeApi participantIntakeApi = clientTransformer.tranform(client);
     participantIntakeApi.setRelatedScreeningId(screeningId);
-    participantIntakeApi = participantService.create(participantIntakeApi);
+    participantIntakeApi = participantService.persistParticipantObjectInNS(participantIntakeApi);
     participantDao.getSessionFactory().getCurrentSession().flush();
     return participantDao.find(participantIntakeApi.getId());
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
Merge participant creation into one implementation
There is no call from Intake to
POST `/screenings/#{screening_id}/participants`
However, there is a call to POST `/screenings/#{screening_id}/participant`
In this story we will remove `/screenings/#{screening_id}/participant`
and move over the functionality to POST `/screenings/#{screening_id}/participants`
Ferb is internally calling the related service for `/screenings/#{screening_id}/participants`
so we will keep that functionality as well in a different method than create

## Jira Issue link
<!--- Provide the link to Jira -->
[Merge participant creation into one implementation](https://osi-cwds.atlassian.net/browse/HOT-2508)

## Tests
- [x] I have included unit tests 
- [ ] I have included functional tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the google code style of this project.
- [x] I have ran all tests for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
