### PR TITLE
HOT-2508 Merge participant creation into one implementation

### DIFF
--- a/src/main/java/gov/ca/cwds/rest/services/screening/participant/ParticipantService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/screening/participant/ParticipantService.java
@@ -95,7 +95,7 @@ public class ParticipantService implements
   private SafelySurrenderedBabiesMapper safelySurrenderedBabiesMapper;
 
   @Inject
-  private ParticipantTransformer participantIntakeApiHelper;
+  private ParticipantTransformer participantTransformer;
 
   /**
    * {@inheritDoc}
@@ -211,7 +211,7 @@ public class ParticipantService implements
       throw new ServiceException("NULL argument for CREATE participant");
     }
     return persistParticipantObjectInNS(
-        participantIntakeApiHelper.prepareParticipantObject(participant));
+        participantTransformer.prepareParticipantObject(participant));
   }
 
   public ParticipantIntakeApi persistParticipantObjectInNS(ParticipantIntakeApi participant) {

--- a/src/test/java/gov/ca/cwds/rest/IntegratedResourceTestSuiteIT.java
+++ b/src/test/java/gov/ca/cwds/rest/IntegratedResourceTestSuiteIT.java
@@ -1,15 +1,13 @@
 package gov.ca.cwds.rest;
 
-import gov.ca.cwds.rest.resources.IntakeLovResourceIRT;
-import gov.ca.cwds.rest.resources.ScreeningParticipantResourceIRT;
-import gov.ca.cwds.rest.resources.relationship.ScreeningRelationshipsWithCandidatesIRT;
-import gov.ca.cwds.rest.resources.ScreeningResourceIRT;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-import gov.ca.cwds.rest.resources.ParticipantIntakeApiResourceIRT;
+import gov.ca.cwds.rest.resources.IntakeLovResourceIRT;
 import gov.ca.cwds.rest.resources.ScreeningIntakeResourceIRT;
+import gov.ca.cwds.rest.resources.ScreeningParticipantResourceIRT;
+import gov.ca.cwds.rest.resources.ScreeningResourceIRT;
 import gov.ca.cwds.rest.resources.auth.AuthorizationResourceIRT;
 import gov.ca.cwds.rest.resources.contact.ContactResourceIRT;
 import gov.ca.cwds.rest.resources.hoi.HoiCaseResourceAuthorizationIRT;
@@ -19,14 +17,15 @@ import gov.ca.cwds.rest.resources.hoi.HoiScreeningResourceIRT;
 import gov.ca.cwds.rest.resources.hoi.HoiUsingClientIdResourceIRT;
 import gov.ca.cwds.rest.resources.hoi.InvolvementHistoryResourceIRT;
 import gov.ca.cwds.rest.resources.relationship.ScreeningRelationshipResourceIRT;
+import gov.ca.cwds.rest.resources.relationship.ScreeningRelationshipsWithCandidatesIRT;
+import gov.ca.cwds.rest.resources.screening.participant.ParticipantResourceIRT;
 import gov.ca.cwds.test.support.BaseDropwizardApplication;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({
-    AuthorizationResourceIRT.class, HoiCaseResourceAuthorizationIRT.class,
+@Suite.SuiteClasses({AuthorizationResourceIRT.class, HoiCaseResourceAuthorizationIRT.class,
     HoiCaseResourceIRT.class, HoiReferralResourceIRT.class, HoiScreeningResourceIRT.class,
     HoiUsingClientIdResourceIRT.class, InvolvementHistoryResourceIRT.class,
-    ScreeningIntakeResourceIRT.class, ParticipantIntakeApiResourceIRT.class,
+    ScreeningIntakeResourceIRT.class, ParticipantResourceIRT.class,
     ScreeningRelationshipResourceIRT.class, ContactResourceIRT.class,
     ScreeningParticipantResourceIRT.class, ScreeningResourceIRT.class,
     ScreeningRelationshipsWithCandidatesIRT.class, IntakeLovResourceIRT.class})

--- a/src/test/java/gov/ca/cwds/rest/resources/screening/participant/ParticipantResourceIRT.java
+++ b/src/test/java/gov/ca/cwds/rest/resources/screening/participant/ParticipantResourceIRT.java
@@ -1,4 +1,4 @@
-package gov.ca.cwds.rest.resources;
+package gov.ca.cwds.rest.resources.screening.participant;
 
 import static gov.ca.cwds.rest.core.Api.RESOURCE_PARTICIPANTS;
 import static gov.ca.cwds.rest.core.Api.RESOURCE_SCREENINGS;
@@ -6,7 +6,6 @@ import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -20,7 +19,7 @@ import gov.ca.cwds.rest.api.domain.PhoneNumber;
 /**
  * CWDS API Team
  */
-public class ParticipantIntakeApiResourceIRT extends IntakeBaseTest {
+public class ParticipantResourceIRT extends IntakeBaseTest {
 
   @Test
   public void testGet() throws Exception {
@@ -32,7 +31,6 @@ public class ParticipantIntakeApiResourceIRT extends IntakeBaseTest {
   }
 
   @Test
-  @Ignore
   public void testPost() throws Exception {
     String request =
         fixture("fixtures/gov/ca/cwds/rest/resources/participant-intake-api-post-request.json");
@@ -88,7 +86,6 @@ public class ParticipantIntakeApiResourceIRT extends IntakeBaseTest {
   }
 
   @Test
-  @Ignore
   public void testPostUpdateDeleteCycle() throws Exception {
     ParticipantIntakeApi participant = objectMapper.readValue(
         fixture("fixtures/gov/ca/cwds/rest/resources/participant-intake-api-post-request.json")

--- a/src/test/java/gov/ca/cwds/rest/services/screening/participant/ParticipantTransformerTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/screening/participant/ParticipantTransformerTest.java
@@ -1,0 +1,118 @@
+package gov.ca.cwds.rest.services.screening.participant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import javax.persistence.EntityNotFoundException;
+
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+
+import gov.ca.cwds.data.cms.ClientDao;
+import gov.ca.cwds.data.cms.TestIntakeCodeCache;
+import gov.ca.cwds.data.ns.ScreeningDao;
+import gov.ca.cwds.data.persistence.ns.ScreeningEntity;
+import gov.ca.cwds.fixture.ParticipantIntakeApiResourceBuilder;
+import gov.ca.cwds.fixture.ScreeningEntityBuilder;
+import gov.ca.cwds.rest.api.domain.LegacyDescriptor;
+import gov.ca.cwds.rest.api.domain.ParticipantIntakeApi;
+import gov.ca.cwds.rest.api.domain.cms.LegacyTable;
+import gov.ca.cwds.rest.api.domain.enums.ScreeningStatus;
+import gov.ca.cwds.rest.services.ServiceException;
+import gov.ca.cwds.rest.services.screeningparticipant.ParticipantDaoFactoryImpl;
+import gov.ca.cwds.rest.services.screeningparticipant.ParticipantMapperFactoryImpl;
+
+/**
+ * @author CWDS API Team
+ */
+public class ParticipantTransformerTest {
+
+  /**
+   * Initialize intake code cache
+   */
+  private TestIntakeCodeCache testIntakeCodeCache = new TestIntakeCodeCache();
+
+  private ParticipantTransformer participantTransformer = new ParticipantTransformer();
+  private ScreeningDao screeningDao;
+  private ClientDao clientDao;
+  private ParticipantService participantService;
+  private ParticipantDaoFactoryImpl participantDaoFactory;
+  private ParticipantMapperFactoryImpl participantMapperFactoryImpl;
+
+  @Before
+  public void setup() {
+    screeningDao = mock(ScreeningDao.class);
+    participantService = mock(ParticipantService.class);
+    participantDaoFactory = mock(ParticipantDaoFactoryImpl.class);
+    participantMapperFactoryImpl = mock(ParticipantMapperFactoryImpl.class);
+    clientDao = mock(ClientDao.class);
+
+    participantTransformer.setScreeningDao(screeningDao);
+    participantTransformer.setParticipantDaoFactory(participantDaoFactory);
+    participantTransformer.setParticipantMapperFactoryImpl(participantMapperFactoryImpl);
+  }
+
+  /**
+   *
+   */
+  @Test(expected = EntityNotFoundException.class)
+  public void testScreeningIdNotFoundInPostgres() {
+    LegacyDescriptor legacyDescriptor = new LegacyDescriptor("Abc1234567", null, new DateTime(),
+        LegacyTable.REPORTER.getName(), null);
+    ParticipantIntakeApi participantIntakeApi = new ParticipantIntakeApiResourceBuilder()
+        .setScreeningId("18").setLegacyDescriptor(legacyDescriptor).build();
+    participantTransformer.prepareParticipantObject(participantIntakeApi);
+  }
+
+  /**
+   *
+   */
+  @Test(expected = ServiceException.class)
+  public void testScreeningIdNull() {
+    LegacyDescriptor legacyDescriptor = new LegacyDescriptor("Abc1234567", null, new DateTime(),
+        LegacyTable.REPORTER.getName(), null);
+    ParticipantIntakeApi participantIntakeApi = new ParticipantIntakeApiResourceBuilder()
+        .setScreeningId(null).setLegacyDescriptor(legacyDescriptor).build();
+    participantTransformer.prepareParticipantObject(participantIntakeApi);
+    assertThat("issue_details[0].technical_message", is(equalTo("Screening not found")));
+  }
+
+  /**
+   *
+   */
+  @Test(expected = ServiceException.class)
+  public void testScreeningIsSubmitted() {
+    LegacyDescriptor legacyDescriptor = new LegacyDescriptor("Abc1234567", null, new DateTime(),
+        LegacyTable.REPORTER.getName(), null);
+    ParticipantIntakeApi participantIntakeApi = new ParticipantIntakeApiResourceBuilder()
+        .setScreeningId("12").setLegacyDescriptor(legacyDescriptor).build();
+    ScreeningEntity screeningEntity = new ScreeningEntityBuilder().setId("12")
+        .setScreeningStatus(ScreeningStatus.SUBMITTED.getStatus()).build();
+    when(screeningDao.find(anyString())).thenReturn(screeningEntity);
+    participantTransformer.prepareParticipantObject(participantIntakeApi);
+    assertThat("issue_details[0].technical_message",
+        is(equalTo("Screeening is already Submitted")));
+  }
+
+  /**
+   *
+   */
+  @Test
+  public void prepareParticipantObjectNewParticipant() {
+    ParticipantIntakeApi participantIntakeApi = new ParticipantIntakeApiResourceBuilder()
+        .setScreeningId("18").setLegacyDescriptor(null).build();
+    when(screeningDao.find(any(String.class))).thenReturn(new ScreeningEntity());
+    when(participantService.persistParticipantObjectInNS(any())).thenReturn(participantIntakeApi);
+    ParticipantIntakeApi expected =
+        participantTransformer.prepareParticipantObject(participantIntakeApi);
+    assertThat(expected, is(notNullValue()));
+  }
+
+}

--- a/src/test/resources/fixtures/gov/ca/cwds/rest/resources/participant-intake-api-post-request.json
+++ b/src/test/resources/fixtures/gov/ca/cwds/rest/resources/participant-intake-api-post-request.json
@@ -69,8 +69,9 @@
   "sealed": false,
   "sensitive": false,
   "probation_youth": true,
+  "screening_id": "36",
   "legacy_descriptor": {
-    "legacy_id": "9C7kKgc0CN",
+    "legacy_id": "",
     "legacy_ui_id": "0522-3101-9120-2000767",
     "legacy_last_updated": "1998-09-16T16:48:05.701-0700",
     "legacy_table_name": "CLIENT_T",

--- a/src/test/resources/fixtures/gov/ca/cwds/rest/resources/participant-intake-api-post-response.json
+++ b/src/test/resources/fixtures/gov/ca/cwds/rest/resources/participant-intake-api-post-response.json
@@ -77,7 +77,7 @@
   "sensitive": false,
   "probation_youth": true,
   "legacy_descriptor": {
-    "legacy_id": "9C7kKgc0CN",
+    "legacy_id": "",
     "legacy_ui_id": "0522-3101-9120-2000767",
     "legacy_last_updated": "1998-09-16T16:48:05.701-0700",
     "legacy_table_name": "CLIENT_T",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
Merge participant creation into one implementation
There is no call from Intake to
POST `/screenings/#{screening_id}/participants`
However, there is a call to POST `/screenings/#{screening_id}/participant`
In this story we will remove `/screenings/#{screening_id}/participant`
and move over the functionality to POST `/screenings/#{screening_id}/participants`
Ferb is internally calling the related service for `/screenings/#{screening_id}/participants`
so we will keep that functionality as well in a different method than create

## Jira Issue link
<!--- Provide the link to Jira -->
[Merge participant creation into one implementation](https://osi-cwds.atlassian.net/browse/HOT-2508)

## Tests
- [x] I have included unit tests 
- [ ] I have included functional tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the google code style of this project.
- [x] I have ran all tests for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
