### PR TITLE
HOT-2508 unit tests and probation youth flag

### DIFF
--- a/src/main/java/gov/ca/cwds/rest/resources/screening/participant/ParticipantResource.java
+++ b/src/main/java/gov/ca/cwds/rest/resources/screening/participant/ParticipantResource.java
@@ -165,4 +165,11 @@ public class ParticipantResource {
         participant);
   }
 
+  public void setResourceDelegate(
+      TypedResourceDelegate<ParticipantResourceParameters, ParticipantIntakeApi> resourceDelegate) {
+    this.resourceDelegate = resourceDelegate;
+  }
+
+
+
 }

--- a/src/main/java/gov/ca/cwds/rest/services/screening/participant/ParticipantTransformer.java
+++ b/src/main/java/gov/ca/cwds/rest/services/screening/participant/ParticipantTransformer.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import com.google.inject.Inject;
 
 import gov.ca.cwds.data.CrudsDao;
+import gov.ca.cwds.data.cms.ClientDao;
 import gov.ca.cwds.data.ns.ScreeningDao;
 import gov.ca.cwds.data.persistence.cms.CmsPersistentObject;
 import gov.ca.cwds.data.persistence.ns.ScreeningEntity;
@@ -22,7 +23,7 @@ import gov.ca.cwds.rest.services.screeningparticipant.ParticipantMapperFactoryIm
 
 /**
  * Business layer object to work on ParticipantIntakeApi
- *
+ * 
  * @author CWDS API Team
  */
 public class ParticipantTransformer {
@@ -37,6 +38,9 @@ public class ParticipantTransformer {
 
   @Inject
   private ParticipantMapperFactoryImpl<CmsPersistentObject> participantMapperFactoryImpl;
+
+  @Inject
+  private ClientDao clientDao;
 
   public ParticipantIntakeApi prepareParticipantObject(
       ParticipantIntakeApi incomingParticipantIntakeApi) {
@@ -54,6 +58,7 @@ public class ParticipantTransformer {
       participantIntakeApi =
           transformParticipant(legacyDescriptor.getId(), legacyDescriptor.getTableName());
       participantIntakeApi.setScreeningId(incomingParticipantIntakeApi.getScreeningId());
+      participantIntakeApi.setProbationYouth(isProbationYouth(legacyDescriptor.getId()));
       return participantIntakeApi;
     } else {
       return incomingParticipantIntakeApi;
@@ -84,11 +89,25 @@ public class ParticipantTransformer {
     }
   }
 
+
+  private Boolean isProbationYouth(String clientId) {
+    return clientDao.findProbationYouth(clientId) != null;
+  }
+
+
   /**
    * @param screeningDao - screeningDao
    */
   public void setScreeningDao(ScreeningDao screeningDao) {
     this.screeningDao = screeningDao;
+  }
+
+
+  /**
+   * @param clientDao - clientDao
+   */
+  public void setClientDao(ClientDao clientDao) {
+    this.clientDao = clientDao;
   }
 
   /**

--- a/src/test/java/gov/ca/cwds/rest/resources/screening/participant/ParticipantResourceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/resources/screening/participant/ParticipantResourceTest.java
@@ -1,0 +1,45 @@
+package gov.ca.cwds.rest.resources.screening.participant;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import gov.ca.cwds.fixture.ParticipantIntakeApiResourceBuilder;
+import gov.ca.cwds.rest.api.domain.ParticipantIntakeApi;
+import gov.ca.cwds.rest.resources.TypedResourceDelegate;
+import gov.ca.cwds.rest.resources.parameter.ParticipantResourceParameters;
+
+/**
+ * @author CWDS API Team
+ *
+ */
+public class ParticipantResourceTest {
+
+  ParticipantResource participantResource;
+  TypedResourceDelegate<ParticipantResourceParameters, ParticipantIntakeApi> typedResourceDelegate;
+  ParticipantIntakeApi participantIntakeApi;
+
+  /**
+   * 
+   */
+  @SuppressWarnings("unchecked")
+  @Before
+  public void setup() {
+    typedResourceDelegate = mock(TypedResourceDelegate.class);
+    participantResource = new ParticipantResource();
+    participantResource.setResourceDelegate(typedResourceDelegate);
+  }
+
+  /**
+   * 
+   */
+  @Test
+  public void whenCreateIsInvoledThenWeShouldCallService() {
+    participantIntakeApi = new ParticipantIntakeApiResourceBuilder().build();
+    participantResource.create("12", participantIntakeApi);
+    verify(typedResourceDelegate).create(participantIntakeApi);
+  }
+
+}

--- a/src/test/java/gov/ca/cwds/rest/services/screening/participant/ParticipantTransformerTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/screening/participant/ParticipantTransformerTest.java
@@ -15,11 +15,17 @@ import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 
+import gov.ca.cwds.data.CrudsDao;
 import gov.ca.cwds.data.cms.ClientDao;
 import gov.ca.cwds.data.cms.TestIntakeCodeCache;
 import gov.ca.cwds.data.ns.ScreeningDao;
+import gov.ca.cwds.data.persistence.cms.Client;
+import gov.ca.cwds.data.persistence.cms.CmsPersistentObject;
+import gov.ca.cwds.data.persistence.cms.Reporter;
 import gov.ca.cwds.data.persistence.ns.ScreeningEntity;
+import gov.ca.cwds.fixture.ClientEntityBuilder;
 import gov.ca.cwds.fixture.ParticipantIntakeApiResourceBuilder;
+import gov.ca.cwds.fixture.ReporterEntityBuilder;
 import gov.ca.cwds.fixture.ScreeningEntityBuilder;
 import gov.ca.cwds.rest.api.domain.LegacyDescriptor;
 import gov.ca.cwds.rest.api.domain.ParticipantIntakeApi;
@@ -27,7 +33,9 @@ import gov.ca.cwds.rest.api.domain.cms.LegacyTable;
 import gov.ca.cwds.rest.api.domain.enums.ScreeningStatus;
 import gov.ca.cwds.rest.services.ServiceException;
 import gov.ca.cwds.rest.services.screeningparticipant.ParticipantDaoFactoryImpl;
+import gov.ca.cwds.rest.services.screeningparticipant.ParticipantMapper;
 import gov.ca.cwds.rest.services.screeningparticipant.ParticipantMapperFactoryImpl;
+import gov.ca.cwds.rest.services.screeningparticipant.ReporterTransformer;
 
 /**
  * @author CWDS API Team
@@ -42,19 +50,20 @@ public class ParticipantTransformerTest {
   private ParticipantTransformer participantTransformer = new ParticipantTransformer();
   private ScreeningDao screeningDao;
   private ClientDao clientDao;
-  private ParticipantService participantService;
   private ParticipantDaoFactoryImpl participantDaoFactory;
   private ParticipantMapperFactoryImpl participantMapperFactoryImpl;
+  private ParticipantMapper<CmsPersistentObject> participantMapper;
+
 
   @Before
   public void setup() {
     screeningDao = mock(ScreeningDao.class);
-    participantService = mock(ParticipantService.class);
     participantDaoFactory = mock(ParticipantDaoFactoryImpl.class);
     participantMapperFactoryImpl = mock(ParticipantMapperFactoryImpl.class);
     clientDao = mock(ClientDao.class);
 
     participantTransformer.setScreeningDao(screeningDao);
+    participantTransformer.setClientDao(clientDao);
     participantTransformer.setParticipantDaoFactory(participantDaoFactory);
     participantTransformer.setParticipantMapperFactoryImpl(participantMapperFactoryImpl);
   }
@@ -102,6 +111,30 @@ public class ParticipantTransformerTest {
   }
 
   /**
+  *
+  */
+  @Test
+  public void prepareParticipantObjectWithLegacyDescriptor() {
+    Reporter reporter = new ReporterEntityBuilder().build();
+    Client probationYouthClient = new ClientEntityBuilder().build();
+    CrudsDao<CmsPersistentObject> crudsDaoObject = mock(CrudsDao.class);
+    when(crudsDaoObject.find(any(String.class))).thenReturn(reporter);
+    when(participantMapperFactoryImpl.create(any(String.class)))
+        .thenReturn(new ReporterTransformer());
+    LegacyDescriptor legacyDescriptor = new LegacyDescriptor("Abc1234567", null, new DateTime(),
+        LegacyTable.REPORTER.getName(), null);
+    ParticipantIntakeApi participantIntakeApi = new ParticipantIntakeApiResourceBuilder()
+        .setScreeningId("18").setLegacyDescriptor(legacyDescriptor).build();
+    when(screeningDao.find(any(String.class))).thenReturn(new ScreeningEntity());
+    when(clientDao.findProbationYouth(any(String.class))).thenReturn(probationYouthClient);
+    when(participantDaoFactory.create(any(String.class))).thenReturn(crudsDaoObject);
+    ParticipantIntakeApi expected =
+        participantTransformer.prepareParticipantObject(participantIntakeApi);
+    assertThat(expected, is(notNullValue()));
+    assertThat(expected.isProbationYouth(), is(Boolean.TRUE));
+  }
+
+  /**
    *
    */
   @Test
@@ -109,7 +142,6 @@ public class ParticipantTransformerTest {
     ParticipantIntakeApi participantIntakeApi = new ParticipantIntakeApiResourceBuilder()
         .setScreeningId("18").setLegacyDescriptor(null).build();
     when(screeningDao.find(any(String.class))).thenReturn(new ScreeningEntity());
-    when(participantService.persistParticipantObjectInNS(any())).thenReturn(participantIntakeApi);
     ParticipantIntakeApi expected =
         participantTransformer.prepareParticipantObject(participantIntakeApi);
     assertThat(expected, is(notNullValue()));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
Merge participant creation into one implementation
There is no call from Intake to
POST `/screenings/#{screening_id}/participants`
However, there is a call to POST `/screenings/#{screening_id}/participant`
In this story we will remove `/screenings/#{screening_id}/participant`
and move over the functionality to POST `/screenings/#{screening_id}/participants`
Ferb is internally calling the related service for `/screenings/#{screening_id}/participants`
so we will keep that functionality as well in a different method than create

## Jira Issue link
<!--- Provide the link to Jira -->
[Merge participant creation into one implementation](https://osi-cwds.atlassian.net/browse/HOT-2508)

## Tests
- [x] I have included unit tests 
- [ ] I have included functional tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the google code style of this project.
- [x] I have ran all tests for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
