### PR TITLE
Hot 2540 remove unused env variables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ applicationDefaultJvmArgs = ["-Djava.library.path=.:./lib:/var/lib/jenkins/works
 
 project.ext {
     coreApiVersion = '1.7.5_855-RC'
-    apiVersion = '0.9.1'
+    apiVersion = '0.9.3'
     cwdsModelVersion = '0.9.2_673-RC'
     configPath = '$rootProject.projectDir/config/'
     dropwizardVersion = '1.1.0'

--- a/src/main/java/gov/ca/cwds/inject/DataAccessModule.java
+++ b/src/main/java/gov/ca/cwds/inject/DataAccessModule.java
@@ -134,8 +134,6 @@ public class DataAccessModule extends AbstractModule {
     LOGGER.warn("DataAccessModule: static point 1");
   }
 
-  // private Map<String, Client> clients;
-
   private final PaperTrailInterceptor paperTrailInterceptor = new PaperTrailInterceptor();
 
   // CMS:

--- a/src/main/java/gov/ca/cwds/inject/DataAccessModule.java
+++ b/src/main/java/gov/ca/cwds/inject/DataAccessModule.java
@@ -7,14 +7,8 @@ import static gov.ca.cwds.rest.core.Api.DS_XA_CMS;
 import static gov.ca.cwds.rest.core.Api.DS_XA_CMS_RS;
 import static gov.ca.cwds.rest.core.Api.DS_XA_NS;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import javax.transaction.SystemException;
 
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.transport.TransportClient;
 import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,7 +63,6 @@ import gov.ca.cwds.data.dao.contact.ContactPartyDeliveredServiceDao;
 import gov.ca.cwds.data.dao.contact.DeliveredServiceDao;
 import gov.ca.cwds.data.dao.contact.IndividualDeliveredServiceDao;
 import gov.ca.cwds.data.dao.contact.ReferralClientDeliveredServiceDao;
-import gov.ca.cwds.data.es.ElasticsearchDao;
 import gov.ca.cwds.data.legacy.cms.dao.PlacementEpisodeDao;
 import gov.ca.cwds.data.legacy.cms.dao.SafetyAlertDao;
 import gov.ca.cwds.data.legacy.cms.dao.SexualExploitationTypeDao;
@@ -107,8 +100,6 @@ import gov.ca.cwds.data.persistence.xa.CandaceSessionFactoryImpl;
 import gov.ca.cwds.data.persistence.xa.XaCmsRsHibernateBundle;
 import gov.ca.cwds.data.rules.TriggerTablesDao;
 import gov.ca.cwds.rest.ApiConfiguration;
-import gov.ca.cwds.rest.ElasticUtils;
-import gov.ca.cwds.rest.ElasticsearchConfiguration;
 import gov.ca.cwds.rest.TriggerTablesConfiguration;
 import gov.ca.cwds.rest.business.rules.LACountyTrigger;
 import gov.ca.cwds.rest.business.rules.NonLACountyTriggers;
@@ -143,7 +134,7 @@ public class DataAccessModule extends AbstractModule {
     LOGGER.warn("DataAccessModule: static point 1");
   }
 
-  private Map<String, Client> clients;
+  // private Map<String, Client> clients;
 
   private final PaperTrailInterceptor paperTrailInterceptor = new PaperTrailInterceptor();
 
@@ -633,75 +624,13 @@ public class DataAccessModule extends AbstractModule {
     return new CandaceDatasourceSlate(sfCms, sfNs, sfCmsRs);
   }
 
-  // ==========================
-  // Elasticsearch
-  // ==========================
-
   static {
     LOGGER.warn("DataAccessModule: static point 7");
   }
 
   @Provides
-  public Map<String, ElasticsearchConfiguration> elasticSearchConfigs(
-      ApiConfiguration apiConfiguration) {
-    return apiConfiguration.getElasticsearchConfigurations();
-  }
-
-  @Provides
   public TriggerTablesConfiguration triggerTablesConfiguration(ApiConfiguration apiConfiguration) {
     return apiConfiguration.getTriggerTablesConfiguration();
-  }
-
-  @Provides
-  @Named("elasticsearch.daos")
-  public synchronized Map<String, ElasticsearchDao> provideElasticSearchDaos(
-      ApiConfiguration apiConfiguration) {
-    if (clients == null) {
-      provideElasticsearchClients(apiConfiguration);
-    }
-
-    final Map<String, ElasticsearchDao> esDaos = new HashMap<>();
-    for (Map.Entry<String, Client> esKey : clients.entrySet()) {
-      final ElasticsearchConfiguration config =
-          apiConfiguration.getElasticsearchConfigurations().get(esKey.getKey());
-      final ElasticsearchDao dao = new ElasticsearchDao(esKey.getValue(), config);
-      esDaos.put(esKey.getKey(), dao);
-    }
-    return esDaos;
-  }
-
-  @Provides
-  @Named("screenings.index")
-  public ElasticsearchDao provideElasticSearchDaoScreenings(
-      @Named("elasticsearch.daos") Map<String, ElasticsearchDao> esDaos) {
-    return esDaos.get("screeningsIndex");
-  }
-
-  private synchronized Map<String, Client> makeElasticsearchClients(
-      ApiConfiguration apiConfiguration) {
-    if (clients == null) {
-      clients = new ConcurrentHashMap<>();
-      final Map<String, ElasticsearchConfiguration> esConfigs =
-          apiConfiguration.getElasticsearchConfigurations();
-
-      for (Map.Entry<String, ElasticsearchConfiguration> esConfigKey : esConfigs.entrySet()) {
-        final ElasticsearchConfiguration config = esConfigs.get(esConfigKey.getKey());
-        final TransportClient transportClient = ElasticUtils.buildElasticsearchClient(config);
-        clients.put(esConfigKey.getKey(), transportClient);
-      }
-    }
-
-    return clients;
-  }
-
-  @Provides
-  public synchronized Map<String, Client> provideElasticsearchClients(
-      ApiConfiguration apiConfiguration) {
-    if (clients == null) {
-      makeElasticsearchClients(apiConfiguration);
-    }
-
-    return clients;
   }
 
   public PaperTrailInterceptor getPaperTrailInterceptor() {

--- a/src/main/java/gov/ca/cwds/rest/services/ScreeningService.java
+++ b/src/main/java/gov/ca/cwds/rest/services/ScreeningService.java
@@ -14,10 +14,8 @@ import org.apache.commons.lang3.NotImplementedException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 
 import gov.ca.cwds.ObjectMapperUtils;
-import gov.ca.cwds.data.es.ElasticsearchDao;
 import gov.ca.cwds.data.ns.AddressesDao;
 import gov.ca.cwds.data.ns.AgencyDao;
 import gov.ca.cwds.data.ns.AllegationIntakeDao;
@@ -62,9 +60,6 @@ public class ScreeningService implements CrudsService {
 
   private static final ObjectMapper OBJECT_MAPPER = ObjectMapperUtils.createObjectMapper();
 
-  @Named("screenings.index")
-  @Inject
-  private ElasticsearchDao esDao;
 
   @Inject
   private AllegationIntakeDao allegationDao;
@@ -442,10 +437,6 @@ public class ScreeningService implements CrudsService {
     screening.setParticipantIntakeApis(participantIntakeApis);
   }
 
-  void setEsDao(ElasticsearchDao esDao) {
-    this.esDao = esDao;
-  }
-
   void setScreeningDao(ScreeningDao screeningDao) {
     this.screeningDao = screeningDao;
   }
@@ -536,10 +527,6 @@ public class ScreeningService implements CrudsService {
 
   public void setCrossReportMapper(CrossReportMapper crossReportMapper) {
     this.crossReportMapper = crossReportMapper;
-  }
-
-  public ElasticsearchDao getEsDao() {
-    return esDao;
   }
 
   public ScreeningDao getScreeningDao() {

--- a/src/test/java/gov/ca/cwds/inject/DataAccessModuleTest.java
+++ b/src/test/java/gov/ca/cwds/inject/DataAccessModuleTest.java
@@ -6,10 +6,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.elasticsearch.client.Client;
 import org.hibernate.SessionFactory;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,10 +14,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
-import gov.ca.cwds.data.es.ElasticsearchDao;
 import gov.ca.cwds.data.persistence.ns.papertrail.PaperTrailInterceptor;
 import gov.ca.cwds.rest.ApiConfiguration;
-import gov.ca.cwds.rest.ElasticsearchConfiguration;
 import gov.ca.cwds.rest.TriggerTablesConfiguration;
 import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.setup.Bootstrap;
@@ -130,36 +124,10 @@ public class DataAccessModuleTest {
   }
 
   @Test
-  public void elasticSearchConfigs_A$ApiConfiguration() throws Exception {
-    Map<String, ElasticsearchConfiguration> actual = target.elasticSearchConfigs(apiConfiguration);
-    assertThat(actual, is(notNullValue()));
-  }
-
-  @Test
   public void triggerTablesConfiguration_A$ApiConfiguration() throws Exception {
     TriggerTablesConfiguration actual = target.triggerTablesConfiguration(apiConfiguration);
     TriggerTablesConfiguration expected = null;
     assertThat(actual, is(equalTo(expected)));
-  }
-
-  @Test
-  public void provideElasticSearchDaos_A$ApiConfiguration() throws Exception {
-    Map<String, ElasticsearchDao> actual = target.provideElasticSearchDaos(apiConfiguration);
-    assertThat(actual, is(notNullValue()));
-  }
-
-  @Test
-  public void provideEelasticSearchDaoScreenings_A$Map() throws Exception {
-    Map<String, ElasticsearchDao> esDaos = new HashMap<String, ElasticsearchDao>();
-    ElasticsearchDao actual = target.provideElasticSearchDaoScreenings(esDaos);
-    ElasticsearchDao expected = null;
-    assertThat(actual, is(expected));
-  }
-
-  @Test
-  public void provideElasticsearchClients_A$ApiConfiguration() throws Exception {
-    Map<String, Client> actual = target.provideElasticsearchClients(apiConfiguration);
-    assertThat(actual, is(notNullValue()));
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/rest/services/ScreeningServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/ScreeningServiceTest.java
@@ -123,7 +123,6 @@ public class ScreeningServiceTest extends Doofenshmirtz<ScreeningEntity> {
     when(crossReportDao.findByScreeningId(any(String.class))).thenReturn(crossReportEntities);
 
     target = new ScreeningService();
-    target.setEsDao(esDao);
     target.setScreeningDao(screeningDao);
     target.setScreeningMapper(screeningMapper);
     target.setAllegationDao(allegationDao);
@@ -216,22 +215,13 @@ public class ScreeningServiceTest extends Doofenshmirtz<ScreeningEntity> {
     }
   }
 
-  @Test
-  public void testUpdatePrimaryKeyObjectTypMismatchn() {
-    try {
-      target.update(new Integer(1), null);
-      fail("Expected exception");
-    } catch (java.lang.AssertionError e) {
-    }
-  }
-
   @Test(expected = ServiceException.class)
   public void testUpdateRequestObjectTypMismatchn() {
     final Request request = new Screening();
     target.update("abc", request);
   }
 
-  @Test(expected = ServiceException.class)
+  @Test
   public void testCreateRequestObjectTypMismatchn() {
     final Request request = new Screening();
     target.create(request);
@@ -294,23 +284,22 @@ public class ScreeningServiceTest extends Doofenshmirtz<ScreeningEntity> {
     assertThat(actual, is(equalTo(expected)));
   }
 
-  @Test(expected = ServiceException.class)
+  @Test
   public void create_A$Request() throws Exception {
     final Request request = new Screening();
     final Screening actual = target.create(request);
     final Screening expected = null;
-    assertThat(actual, is(equalTo(expected)));
+    assertThat(actual.getId(), is(equalTo(expected)));
   }
 
-  @Test(expected = ServiceException.class)
+  @Test
   public void update_A$Serializable$Request() throws Exception {
     final Serializable primaryKey = DEFAULT_CLIENT_ID;
     final Screening request = new Screening();
     request.setId(DEFAULT_CLIENT_ID);
 
     final Screening actual = target.update(primaryKey, request);
-    final Screening expected = null;
-    assertThat(actual, is(equalTo(expected)));
+    assertThat(actual.getId(), is(equalTo(DEFAULT_CLIENT_ID)));
   }
 
   @Test

--- a/src/test/java/gov/ca/cwds/rest/services/ScreeningServiceTest.java
+++ b/src/test/java/gov/ca/cwds/rest/services/ScreeningServiceTest.java
@@ -7,7 +7,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.Serializable;
@@ -28,7 +27,6 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import gov.ca.cwds.data.es.ElasticsearchDao;
 import gov.ca.cwds.data.ns.AllegationIntakeDao;
 import gov.ca.cwds.data.ns.CrossReportDao;
 import gov.ca.cwds.data.ns.ScreeningAddressDao;
@@ -58,9 +56,6 @@ public class ScreeningServiceTest extends Doofenshmirtz<ScreeningEntity> {
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
-
-  @Mock
-  private ElasticsearchDao esDao;
 
   @Mock
   private ScreeningDao screeningDao;
@@ -102,14 +97,6 @@ public class ScreeningServiceTest extends Doofenshmirtz<ScreeningEntity> {
   public void setup() throws Exception {
     super.setup();
     MockitoAnnotations.initMocks(this);
-
-    when(esDao.getConfig()).thenReturn(esConfig);
-    when(esDao.getClient()).thenReturn(esClient);
-    when(esConfig.getElasticsearchAlias()).thenReturn("screenings");
-    when(esConfig.getElasticsearchDocType()).thenReturn("screening");
-
-    when(esClient.prepareIndex(any(), any(), any())).thenReturn(indexRequestBuilder);
-    when(indexRequestBuilder.get()).thenReturn(indexResponse);
 
     final ScreeningEntity screeningEntity = new ScreeningEntity();
     when(screeningDao.find(any(Serializable.class))).thenReturn(screeningEntity);
@@ -324,12 +311,6 @@ public class ScreeningServiceTest extends Doofenshmirtz<ScreeningEntity> {
 
     final Screening actual = target.updateScreening(id, request);
     assertThat(actual, is(notNullValue()));
-  }
-
-  @Test
-  public void setEsDao_A$ElasticsearchDao() throws Exception {
-    final ElasticsearchDao esDao = mock(ElasticsearchDao.class);
-    target.setEsDao(esDao);
   }
 
   @Test


### PR DESCRIPTION
Removed the code related to Elastic Search.

## Description
As Ferb API is not using X-Pack, Elastic Search and Smarty Streets so the unused code has been removed and the test cases. 

Below are the Variables will be removed from the lower env yml file:

       **- ES_HOST_PEOPLE
       - ES_PORT_PEOPLE
       - ES_CLUSTER_PEOPLE
       - ES_NODES_PEOPLE
       - ES_HOST_SCREENINGS
       - ES_PORT_SCREENINGS
       - ES_CLUSTER_SCREENINGS
       - ES_NODES_SCREENINGS
       - XPACK_USER_SCREENINGS
       - XPACK_USER_PEOPLE
       - FERB_SS_ID**
  

## Jira Issue link
https://osi-cwds.atlassian.net/browse/HOT-2540

## Tests
- [x] I have included unit tests 
- [ ] I have included functional tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the google code style of this project.
- [x] I have ran all tests for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
