### PR TITLE
FIT-199: Build out a few secure base images for Java

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cwds/javajdk
+FROM cwds/alpinejre
 RUN mkdir /opt/cws-api
 RUN mkdir /opt/cws-api/logs
 ADD config/api.yml /opt/cws-api/api.yml


### PR DESCRIPTION
now using cwds/alpinejre as a base docker image for better security

## Jira Issue link
https://osi-cwds.atlassian.net/browse/FIT-199

