### PR TITLE
DS-3128

### DIFF
--- a/src/main/java/gov/ca/cwds/data/persistence/xa/WorkFerbUserInfo.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/xa/WorkFerbUserInfo.java
@@ -92,8 +92,10 @@ public class WorkFerbUserInfo implements Work {
         // platform.
         db2con.setDB2ClientUser(userId);
         db2con.setDB2ClientAccountingInformation(staffId);
-        db2con.setDB2ClientApplicationInformation(PROGRAM_NAME);
         db2con.setDB2ClientWorkstation(WORKSTATION);
+
+        // DS-3128: set by environment in JDBC URL:
+        // db2con.setDB2ClientApplicationInformation(PROGRAM_NAME);
 
         // Verify that DB2 "special registers" for client user info are indeed set.
         // Ronald Reagan: "Trust -- but verify."

--- a/src/main/java/gov/ca/cwds/data/persistence/xa/WorkFerbUserInfo.java
+++ b/src/main/java/gov/ca/cwds/data/persistence/xa/WorkFerbUserInfo.java
@@ -87,7 +87,7 @@ public class WorkFerbUserInfo implements Work {
           db2con = (DB2Connection) con;
         }
 
-        // Yes, the DB2 methods are deprecated, but underlying properties *differ* by platform.
+        // Yes, the DB2 methods are deprecated, and underlying properties *differ* by platform.
         // These deprecated methods consistently set the right target property, regardless of
         // platform.
         db2con.setDB2ClientUser(userId);
@@ -140,7 +140,7 @@ public class WorkFerbUserInfo implements Work {
 
         // ALTERNATIVE: call proc SYSPROC.WLM_SET_CLIENT_INFO.
       } catch (Exception e) {
-        LOGGER.warn("Unsupported client info: {}", e.getMessage(), e);
+        LOGGER.warn("UNSUPPORTED CLIENT INFO: {}", e.getMessage(), e);
       }
     }
   }

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -4,7 +4,7 @@ appender.console.layout.type = PatternLayout
 
 
 log4j.appender.jdbcLog=org.apache.log4j.RollingFileAppender
-log4j.appender.jdbcLog.File=log/jdbc.log
+log4j.appender.jdbcLog.File=logs/jdbc.log
 log4j.appender.jdbcLog.Threshold=DEBUG
 log4j.appender.jdbcLog.MaxFileSize=10MB
 log4j.appender.jdbcLog.MaxBackupIndex=20


### PR DESCRIPTION
Don't overwrite the DB2 program information field, which is set by the JDBC URL parameter.

## Description
An override of DB2 program info makes it hard to identify Ferb instances by DB2 admins.

## Jira Issue link
https://osi-cwds.atlassian.net/browse/DS-3128

## Tests
- [ ] I have included unit tests 
- [ ] I have included functional tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
Logs show that DB2 program info is set correctly. DBA confirms.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the google code style of this project.
- [x] I have ran all tests for the project.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check SonarQube after the build completes, use best practices, to leave the code in better shape than I found it, and to have a good day.
